### PR TITLE
Add processing for `neutral` RANK votes

### DIFF
--- a/app/composables/useRankApi.ts
+++ b/app/composables/useRankApi.ts
@@ -19,7 +19,7 @@ type ProfileData = IndexedRanking & {
 }
 
 type VoteActivity = {
-  votes: RankTransactionAPI
+  votes: RankTransactionAPI[]
   numPages: number
 }
 
@@ -30,8 +30,14 @@ type RankTransactionAPI = {
   scriptPayload: string
   txid: string
   sentiment: ScriptChunkSentimentUTF8
+  firstSeen: string // bigint to string
   timestamp: string // bigint to string
   sats: string // bigint to string
+}
+
+type ProfileVoteActivity = {
+  votes: ProfileRankTransactionAPI[]
+  numPages: number
 }
 
 type ProfileRankTransactionAPI = {
@@ -49,9 +55,11 @@ type ProfileRankTransactionAPI = {
  */
 type ProfilesAPI = {
   profiles: Array<{
-    platform: ScriptChunkPlatformUTF8
     id: string
-    ranking: number
+    platform: string
+    ranking: string
+    satsPositive: string
+    satsNegative: string
     votesPositive: number
     votesNegative: number
   }>
@@ -115,41 +123,33 @@ export const useRankApi = () => {
   }
 
   const getTopRankedProfiles = async (
-    timespan?: Timespan
+    timespan: Timespan = 'today'
   ): Promise<APIResponse[]> => {
-    const url = `${RANK_API_URL}/stats/profiles/top-ranked${
-      timespan ? `/${timespan}` : ''
-    }`
+    const url = `${RANK_API_URL}/stats/profiles/top-ranked/${timespan}`
     const response = await fetch(url)
     return (await response.json()) as APIResponse[]
   }
 
   const getLowestRankedProfiles = async (
-    timespan?: Timespan
+    timespan: Timespan = 'today'
   ): Promise<APIResponse[]> => {
-    const url = `${RANK_API_URL}/stats/profiles/lowest-ranked${
-      timespan ? `/${timespan}` : ''
-    }`
+    const url = `${RANK_API_URL}/stats/profiles/lowest-ranked/${timespan}`
     const response = await fetch(url)
     return (await response.json()) as APIResponse[]
   }
 
   const getTopRankedPosts = async (
-    timespan?: Timespan
+    timespan: Timespan = 'today'
   ): Promise<APIResponse[]> => {
-    const url = `${RANK_API_URL}/stats/posts/top-ranked${
-      timespan ? `/${timespan}` : ''
-    }`
+    const url = `${RANK_API_URL}/stats/posts/top-ranked/${timespan}`
     const response = await fetch(url)
     return (await response.json()) as APIResponse[]
   }
 
   const getLowestRankedPosts = async (
-    timespan?: Timespan
+    timespan: Timespan = 'today'
   ): Promise<APIResponse[]> => {
-    const url = `${RANK_API_URL}/stats/posts/lowest-ranked${
-      timespan ? `/${timespan}` : ''
-    }`
+    const url = `${RANK_API_URL}/stats/posts/lowest-ranked/${timespan}`
     const response = await fetch(url)
     return (await response.json()) as APIResponse[]
   }
@@ -168,13 +168,10 @@ export const useRankApi = () => {
     profileId: string,
     page: number = 1,
     pageSize: number = 10
-  ): Promise<{ votes: ProfileRankTransactionAPI[], numPages: number }> => {
+  ): Promise<ProfileVoteActivity> => {
     const url = `${RANK_API_URL}/txs/${platform}/${profileId}/${page}/${pageSize}`
     const response = await fetch(url)
-    return (await response.json()) as {
-      votes: ProfileRankTransactionAPI[]
-      numPages: number
-    }
+    return (await response.json()) as ProfileVoteActivity
   }
 
   const getPostRanking = async (

--- a/app/pages/explorer/tx/[txid].vue
+++ b/app/pages/explorer/tx/[txid].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { formatTimestamp, truncateTxid, truncateBlockHash, truncateAddress } from '~/utils/functions'
+import { formatTimestamp, truncateTxid, truncateBlockHash, truncateAddress, toUppercaseFirstLetter, getSentimentColor } from '~/utils/functions'
 
 definePageMeta({
   layout: 'explorer',
@@ -271,12 +271,12 @@ useSeoMeta({
                       <ExplorerAmountXPI :sats="output.value" />
                       <UBadge
                         v-if="output.rankOutput"
-                        :color="output.rankOutput.sentiment == 'positive' ? 'green' : 'red'"
+                        :color="getSentimentColor(output.rankOutput.sentiment)"
                         variant="subtle"
                         size="xs"
                         class="ml-1"
                       >
-                        {{ output.rankOutput.sentiment == 'positive' ? 'Positive' : 'Negative' }}
+                        {{ toUppercaseFirstLetter(output.rankOutput.sentiment) }}
                       </UBadge>
                     </div>
                     <span class="text-sm">

--- a/app/pages/social/[platform]/[profileId]/index.vue
+++ b/app/pages/social/[platform]/[profileId]/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ScriptChunkPlatformUTF8 } from '~/submodules/rank-lib'
 import { PlatformIcon, PlatformURL } from '~/utils/constants'
-import { toPercentColor, truncateTxid, formatTimestamp, toUppercaseFirstLetter, toMinifiedPercent, toMinifiedStatCount, getTrendColor } from '~/utils/functions'
+import { toPercentColor, truncateTxid, formatTimestamp, toUppercaseFirstLetter, toMinifiedPercent, toMinifiedStatCount, getRankingColor } from '~/utils/functions'
 
 definePageMeta({
   layout: 'explorer'
@@ -255,7 +255,7 @@ useSeoMeta({
                 </NuxtLink>
               </template>
               <template #ranking-data="{ row }">
-                <span :class="getTrendColor(row.ranking)">
+                <span :class="getRankingColor(row.ranking)">
                   {{ toMinifiedStatCount(row.ranking) }} XPI
                 </span>
               </template>
@@ -342,6 +342,12 @@ useSeoMeta({
                 <span
                   v-else-if="row.sentiment === 'negative'"
                   class="text-red-500 dark:text-red-400"
+                >
+                  {{ toUppercaseFirstLetter(row.sentiment) }}
+                </span>
+                <span
+                  v-else-if="row.sentiment === 'neutral'"
+                  class="text-gray-500 dark:text-gray-400"
                 >
                   {{ toUppercaseFirstLetter(row.sentiment) }}
                 </span>

--- a/app/pages/social/activity.vue
+++ b/app/pages/social/activity.vue
@@ -155,6 +155,16 @@ useSeoMeta({
               />
               {{ toMinifiedStatCount(row.sats) }} XPI
             </span>
+            <span
+              v-else-if="row.sentiment === 'neutral'"
+              class="text-gray-500 dark:text-gray-400 flex items-center"
+            >
+              <UIcon
+                name="i-heroicons-minus-circle"
+                class="mr-1"
+              />
+              {{ toMinifiedStatCount(row.sats) }} XPI
+            </span>
           </template>
           <template #postId-data="{ row }">
             <NuxtLink

--- a/app/server/api/social/[platform]/[profileId]/posts.ts
+++ b/app/server/api/social/[platform]/[profileId]/posts.ts
@@ -1,4 +1,4 @@
-import type { ScriptChunkPlatformUTF8 } from 'rank-lib'
+import type { ScriptChunkPlatformUTF8 } from '~/submodules/rank-lib'
 import { useRankApi } from '~/composables/useRankApi'
 
 const { getProfilePosts } = useRankApi()

--- a/app/utils/functions.ts
+++ b/app/utils/functions.ts
@@ -238,8 +238,19 @@ export function toMinifiedTime(seconds: number | string) {
 }
 
 // Determine trend color based on ranking change
-export function getTrendColor(change: number) {
+export function getRankingColor(change: number) {
   return change > 0 ? 'green' : change < 0 ? 'red' : 'gray'
+}
+
+export function getSentimentColor(sentiment: ScriptChunkSentimentUTF8) {
+  switch (sentiment) {
+    case 'positive':
+      return 'green'
+    case 'negative':
+      return 'red'
+    case 'neutral':
+      return 'gray'
+  }
 }
 
 export function calculateRate(


### PR DESCRIPTION
This branch updates the `rank-lib` submodule to include processing for RANK votes with a `neutral` ranking. This branch also adds correct processing and rendering to the appropriate social pages to display them.