### PR TITLE
Bugfix: Missing `post` object or `postId` in API results

### DIFF
--- a/app/pages/social/[platform]/[profileId]/index.vue
+++ b/app/pages/social/[platform]/[profileId]/index.vue
@@ -352,6 +352,7 @@ useSeoMeta({
               </template>
               <template #postId-data="{ row }">
                 <NuxtLink
+                  v-if="row.post"
                   class="text-sky-500 dark:text-sky-400 hover:text-sky-600 dark:hover:text-sky-300"
                   :to="PlatformURL[platform].post(profileId, row.post.id)"
                   target="_blank"
@@ -365,6 +366,9 @@ useSeoMeta({
                     />
                   </div>
                 </NuxtLink>
+                <span v-else>
+                  Profile RANK vote
+                </span>
               </template>
             </UTable>
 

--- a/app/pages/social/activity.vue
+++ b/app/pages/social/activity.vue
@@ -168,6 +168,7 @@ useSeoMeta({
           </template>
           <template #postId-data="{ row }">
             <NuxtLink
+              v-if="row.postId"
               class="text-sky-500 dark:text-sky-400 hover:text-sky-600 dark:hover:text-sky-300"
               :to="PlatformURL[row.platform].post(row.profileId, row.postId)"
               target="_blank"
@@ -181,6 +182,9 @@ useSeoMeta({
                 />
               </div>
             </NuxtLink>
+            <span v-else>
+              Profile RANK vote
+            </span>
           </template>
         </UTable>
 


### PR DESCRIPTION
This branch fixes a couple small rendering bugs that were present in the `/social/activity` and `/social/[profileId]/index.vue` pages. The lack of a `postId` property or `post` object (respectively) caused table results to not render, or to render improperly. The Vue templates were updated with appropriate conditionals to handle these cases.