### PR TITLE
Implement Testnet detection, `lotus-sdk` bugfixes

### DIFF
--- a/app/composables/useRankApi.ts
+++ b/app/composables/useRankApi.ts
@@ -1,9 +1,8 @@
+import type { ProfileAPI, PostAPI } from 'lotus-sdk'
 import type {
   ScriptChunkPlatformUTF8,
-  ProfileAPI,
-  PostAPI,
   ScriptChunkSentimentUTF8
-} from 'lotus-sdk'
+} from 'lotus-sdk/lib/rank'
 import type {
   APIResponse,
   WalletActivity,
@@ -445,12 +444,12 @@ export const useRankApi = () => {
   }
 
   // Search for profiles across platforms
-  const searchProfiles = async (query: string): Promise<IndexedRanking[]> => {
+  const searchProfiles = async (query: string): Promise<ProfileAPI[]> => {
     if (!query || query.trim().length < 2) return []
     const url = `${RANK_API_URL}/search/profile/${query}`
     try {
       const response = await fetch(url)
-      return (await response.json()) as IndexedRanking[]
+      return (await response.json()) as ProfileAPI[]
     } catch (error) {
       console.error('Error searching profiles:', error)
       return []

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -8,6 +8,18 @@ export default defineNuxtConfig({
         github: 'https://github.com/LotusiaStewardship',
         telegram: 'https://t.me/givelotus'
       }
+    },
+    // Lotus API configuration
+    url: {
+      chronik: process.env.NUXT_URL_CHRONIK,
+      rank: process.env.NUXT_URL_RANK
+    },
+    // Lotus JSON-RPC configuration
+    rpc: {
+      host: process.env.NUXT_LOTUS_RPC_HOST,
+      port: process.env.NUXT_LOTUS_RPC_PORT,
+      user: process.env.NUXT_LOTUS_RPC_USER,
+      password: process.env.NUXT_LOTUS_RPC_PASSWORD
     }
   },
   extends: [process.env.NUXT_UI_PRO_PATH || '@nuxt/ui-pro'],

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,7 +19,7 @@
         "@vueuse/nuxt": "^10.9.0",
         "chronik-client": "0.19.0",
         "date-fns": "4.1.0",
-        "lotus-sdk": "^0.1.1",
+        "lotus-sdk": "0.1.17",
         "nuxt": "^3.17.5",
         "nuxt-site-config": "3.2.11"
       },
@@ -17254,9 +17254,9 @@
       }
     },
     "node_modules/lotus-sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/lotus-sdk/-/lotus-sdk-0.1.1.tgz",
-      "integrity": "sha512-erlPmBoZvzt99GKuoQY3BX8fYXTlAbu852W6seXoOwpjp3W1A5P/1TDsNYaBM4v2yugqCvlN8g37fc4i/d6E8w==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/lotus-sdk/-/lotus-sdk-0.1.17.tgz",
+      "integrity": "sha512-2yFbZbvWfua1ESgc8cYI1AAOpYX8XLvFoRa3J+2sCnDxNSRMSAPAR7meuShM33LBv6H6u9ZQT5o2eEr7RijJWQ==",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/libp2p-noise": "17.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "@vueuse/nuxt": "^10.9.0",
     "chronik-client": "0.19.0",
     "date-fns": "4.1.0",
-    "lotus-sdk": "^0.1.1",
+    "lotus-sdk": "0.1.17",
     "nuxt": "^3.17.5",
     "nuxt-site-config": "3.2.11"
   },

--- a/app/server/api/explorer/address/[address]/index.ts
+++ b/app/server/api/explorer/address/[address]/index.ts
@@ -1,7 +1,11 @@
 import { Bitcore } from 'lotus-sdk'
 import { useChronikApi } from '@/composables/useChronikApi'
 import { getSumBurnedSats } from '~/utils/transaction'
-import { EXPLORER_TABLE_MAX_ROWS } from '~/utils/constants'
+import {
+  EXPLORER_TABLE_MAX_ROWS,
+  NetworkCharacter,
+  Network
+} from '~/utils/constants'
 
 const { getTxHistoryPage } = useChronikApi()
 
@@ -13,6 +17,15 @@ export default defineEventHandler(async (event) => {
     throw createError({
       statusCode: 400,
       statusMessage: 'Missing address'
+    })
+  }
+
+  // Enforce proper address format depending on the network type
+  const networkChar = address.split('lotus')[1].slice(0, 1)
+  if (networkChar !== NetworkCharacter) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Address is not a ${Network} address`
     })
   }
 
@@ -34,7 +47,9 @@ export default defineEventHandler(async (event) => {
     scriptPayload,
     // Chronik tx history page is 0-indexed, but we want to show the user a 1-indexed page
     pageNum > 0 ? pageNum - 1 : 0,
-    pageSizeNum > EXPLORER_TABLE_MAX_ROWS ? EXPLORER_TABLE_MAX_ROWS : pageSizeNum
+    pageSizeNum > EXPLORER_TABLE_MAX_ROWS
+      ? EXPLORER_TABLE_MAX_ROWS
+      : pageSizeNum
   )
 
   // find the address last seen time

--- a/app/server/api/social/[platform]/[profileId]/index.ts
+++ b/app/server/api/social/[platform]/[profileId]/index.ts
@@ -1,4 +1,4 @@
-import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk'
+import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk/lib/rank'
 import { useRankApi } from '~/composables/useRankApi'
 
 const { getProfileRanking } = useRankApi()

--- a/app/server/api/social/[platform]/[profileId]/posts.ts
+++ b/app/server/api/social/[platform]/[profileId]/posts.ts
@@ -1,4 +1,4 @@
-import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk'
+import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk/lib/rank'
 import { useRankApi } from '~/composables/useRankApi'
 
 const { getProfilePosts } = useRankApi()

--- a/app/server/api/social/[platform]/[profileId]/votes.ts
+++ b/app/server/api/social/[platform]/[profileId]/votes.ts
@@ -1,4 +1,4 @@
-import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk'
+import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk/lib/rank'
 import { useRankApi } from '~/composables/useRankApi'
 
 const { getProfileRankTransactions } = useRankApi()

--- a/app/utils/address.ts
+++ b/app/utils/address.ts
@@ -1,4 +1,5 @@
 import { Bitcore } from 'lotus-sdk'
+import { Network } from './constants'
 
 /**
  * Get the address from a script
@@ -16,8 +17,8 @@ const getAddressFromScript = (
   if (script.isDataOut()) {
     return null
   }
-  // P2PKH and P2SH outputs are addresses
-  return Bitcore.Address.fromScript(script, Bitcore.Networks.mainnet)
+  // P2PKH, P2TR, and P2SH outputs are addresses
+  return script.toAddress(Network)
 }
 
 export { getAddressFromScript }

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -10,8 +10,13 @@ export const LotusRPC = {
   password: process.env.NUXT_LOTUS_RPC_PASSWORD
 }
 
+// Used for correct address display based on configured network
 export const Network: 'mainnet' | 'testnet'
   = process.env.NUXT_LOTUS_RPC_PORT === '11604' ? 'testnet' : 'mainnet'
+
+// Used to filter addresses in API requests
+export const NetworkCharacter: '_' | 'T'
+  = process.env.NUXT_LOTUS_RPC_PORT === '11604' ? 'T' : '_'
 
 export const PlatformURL = {
   twitter: {

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,14 +1,17 @@
-export const CHRONIK_API_URL = 'http://172.16.11.102:7123'
+export const CHRONIK_API_URL = process.env.NUXT_URL_CHRONIK
+export const RANK_API_URL = process.env.NUXT_URL_RANK
 // export const NODE_API_URL = 'https://explorer.lotusia.org/api'
 export const NODE_GEOIP_URL = 'https://api.sefinek.net/api/v2/geoip'
-export const RANK_API_URL = 'https://rank.lotusia.org/api/v1'
 
 export const LotusRPC = {
-  address: '172.16.11.101',
-  port: 10604,
-  user: 'lotus',
-  password: 'lotus'
+  address: process.env.NUXT_LOTUS_RPC_HOST,
+  port: process.env.NUXT_LOTUS_RPC_PORT,
+  user: process.env.NUXT_LOTUS_RPC_USER,
+  password: process.env.NUXT_LOTUS_RPC_PASSWORD
 }
+
+export const Network: 'mainnet' | 'testnet'
+  = process.env.NUXT_LOTUS_RPC_PORT === '11604' ? 'testnet' : 'mainnet'
 
 export const PlatformURL = {
   twitter: {
@@ -30,6 +33,7 @@ export const Addresses = {
     judges: 'lotus_16PSJMaps9sQg7aBQgyY1RdHb2fZYdmWhQPbgus75',
     ruth: 'lotus_16PSJPi88MtH34Ti3dZza4MFRF9XUVd3fKc6Ec3TV',
     firstSamuel: 'lotus_16PSJKi4ucDByLHn3mTQaBijiNZmczAdALVDGS53V'
+    // TODO: add secondSamuel address array
   }
 }
 


### PR DESCRIPTION
This commit updates the installed `lotus-sdk` to 0.1.17, which is the latest version necessary to fix some critical runtime bugs, specifically with module/type exports and P2TR address encoding.

We also implement Nuxt `runtimeConfig` for parsing an existing `.env` for JSON-RPC configuration and external API URLs (e.g. Chronik, RANK, etc.). The built-in Explorer modules and API were adjusted to accommodate testnet environments (as opposed to being mainnet-only).

This commit also fixes some RANK transaction processing bugs thanks to the `lotus-sdk` update.