### PR TITLE
content(website): reframe homepage and tools page for Stewardship pos…

### DIFF
--- a/app/content/0.index.yml
+++ b/app/content/0.index.yml
@@ -1,8 +1,8 @@
 title: Welcome to Lotusia
-description: Lotusia builds applications that empower humans to reconnect in a world overrun with bots and algorithms
+description: Lotusia was founded to foster human relationships, build reciprocal culture, and bolster societal value production online and offline
 navigation: false
 hero:
-  title: Powering the Human Resurgence
+  title: Restoring Humanity to Society
   image: '/img/turtles_hero.jpeg'
   links:
     - label: Get Started
@@ -17,45 +17,83 @@ hero:
       icon: i-heroicons-information-circle
       trailing: true
 sections:
-  - title: The Algorithm Works for You Now
-    description: Algorithms aren't the problem—who controls them is. When corporations run the algorithm, they optimize for profit and engagement. When real people with Lotus run it, the algorithm surfaces what the community actually values. Burn Lotus to boost content. Earn influence by holding Lotus. Shape what gets seen.
+  - title: What Is Lotus?
+    description: The Lotusia economy is denominated in the Lotus currency. Lotus combines the best qualities of the modern monetary system and the new generation of digital cryptocurrencies. The result is an ethical currency that is economically viable.
     align: right
     features:
-      - name: Community-Controlled
-        description: The algorithm serves the people who hold Lotus, not advertisers
-        icon: i-heroicons-heart-solid
-      - name: Transparent by Design
-        description: Every vote lives on the blockchain—see exactly how content ranks
-        icon: i-heroicons-shield-check-solid
-      - name: Real Moderation
-        description: People with skin in the game moderate content, not faceless committees
-        icon: i-heroicons-sparkles-solid
-  - title: Your Lotus, Your Voice
-    description: Hold Lotus, gain influence. It's that simple. Whether you mine it, earn it, or get gifted some—your stake in the network gives you a say in how things run. No boardrooms, no shareholders, no VC firms calling the shots.
+      - name: Debt-free
+        description: Lotus is issued through Proof-of-Work mining (electricity)
+        icon: i-heroicons-cog
+      - name: Inflationary
+        description: No arbitrary issuance cap (unlike Bitcoin), therefore no reason to hoard it
+        icon: i-heroicons-arrow-trending-up-solid
+      - name: Abundant
+        description: Issuance of new Lotus is adjusted to demand of the Lotusia economy
+        icon: i-heroicons-sun-solid
+      - name: Stabilizing
+        description: Lotus is removed from circulation through voluntary destructive use to stabilize volatility
+        icon: i-heroicons-scale
+  - title: The Power of Giving
+    description: Reciprocity is the core of all human relationships, whether personal or professional. In many cultures, the lotus flower is a powerful symbol of creation, strength, and resiliency. When you reciprocate to others by giving Lotus, you are giving them a priceless and powerful symbol that represents the value of your relationship with them.
     align: left
     features:
-      - name: Burn to Decide
-        description: Holding Lotus gives you potential—burning it shapes the algorithm. Every burn is a vote that determines what rises.
-        icon: i-heroicons-fire-solid
-      - name: Fully Transparent
-        description: Every transaction, every decision—all recorded on the blockchain
-        icon: i-heroicons-eye-solid
-      - name: No Gatekeepers
-        description: Access the network from anywhere, no permission needed
-        icon: i-heroicons-globe-alt-solid
-      - name: Earn Your Voice
-        description: Get Lotus through mining, community participation, or contribution
-        icon: i-heroicons-trophy-solid
-  - title: Simple Tools, Big Impact
-    description: Start with our Chrome extension—vote on content by burning Lotus, making what matters rise to the top. Or grab BigVase on your phone to manage your wallet, join governance discussions, and find the good stuff. Both are free. Both are yours.
+      - name: '"I tell you, use worldly wealth to gain friends for yourselves, so that when it is gone, you will be welcomed into eternal dwellings."'
+        description: 'Luke 16:9'
+        icon: i-heroicons-book-open-solid
+      - name: '"Do not store up for yourselves treasures on earth, where moths and vermin destroy, and where thieves break in and steal. But store up for yourselves treasures in heaven, where moths and vermin do not destroy, and where thieves do not break in and steal. For where your treasure is, there your heart will be also."'
+        description: 'Matthew 6:19-21'
+        icon: i-heroicons-book-open-solid
+  - title: Ecosystem Alignment
+    description: Societies of the world are suffering from high levels of corruption and poverty due to the misaligned incentives of their governing bodies and banking systems. With the Lotus blockchain, the Stewardship is directly funded voluntarily through the currency issuance mechanism, and they are thus incentivized to increase the prosperity of the Ecosystem.
     align: right
     features:
-      - name: Chrome Extension
-        description: Vote with your wallet—burn Lotus to amplify what deserves attention
-        icon: i-heroicons-computer-desktop-solid
-      - name: BigVase Mobile App
-        description: Your pocket-sized gateway to the Lotusia ecosystem
-        icon: i-heroicons-device-phone-mobile-solid
+      - name: Value proposition
+        description: The Stewardship must propose its plan to produce value for Lotusia prior to receiving funding
+        icon: i-heroicons-document-check-solid
+      - name: Funding transparency
+        description: Currency issued to and spent by the Stewardship is untamperable public record
+        icon: i-heroicons-magnifying-glass
+      - name: Voluntary association
+        description: The Citizenry can dismiss the existing Stewardship and immediately elect a new Stewardship if desired
+        icon: i-heroicons-rectangle-group-solid
+  - title: Public Goods for the Ecosystem
+    description: The Lotusia Stewardship develops and maintains open-source tools, libraries, and infrastructure that power the ecosystem. From blockchain indexers to mobile wallets, these public goods are freely available for anyone to use, modify, and build upon.
+    align: left
+    features:
+      - name: Open Source
+        description: All Stewardship software is open source, auditable, and community-maintained
+        icon: i-heroicons-code-bracket-solid
+      - name: Permissionless
+        description: Anyone can use these tools without restriction
+        icon: i-heroicons-lock-open-solid
+      - name: Extensible
+        description: Build your own applications on top of the Stewardship's infrastructure
+        icon: i-heroicons-puzzle-piece-solid
+  - title: Worldwide Impact
+    description: The Lotus blockchain, due to its interconnected digital nature, is lightning fast and unhindered by borders or other physicalities, allowing Lotusia to spread across the planet. The blockchain also provides the Ecosystem with unbounded capabilities.
+    align: right
+    features:
+      - name: Permissionless
+        description: Everyone is free to join and leave the network at will and give Lotus to anybody, anywhere, at any time
+        icon: i-heroicons-share
+      - name: Versatile
+        description: The programmable nature of the blockchain provides extensive capabilities to meet future demands for trade and other social interactions
+        icon: i-heroicons-cube-transparent
+      - name: Adaptable
+        description: A 6-month regular upgrade schedule of the blockchain software ensures the performance and functionality remains in lockstep with the growth and demand of the Ecosystem
+        icon: i-heroicons-cog
+      - name: Scalable
+        description: The Lotus blockchain is based on Bitcoin ABC software, making it highly scalable
+        icon: i-heroicons-globe-alt
+    links:
+      - label: What is Bitcoin ABC?
+        to: https://bitcoinabc.org
+        target: _blank
+        color: gray
+        icon: i-heroicons-arrow-top-right-on-square
+        trailing: true
+        size: sm
+        class: ml-8
 cta:
-  title: Take Back the Algorithm
-  description: Join a community where real people—not corporations—decide what matters. Get started with Lotus today.
+  title: Society Needs Humanity
+  description: It takes all of us making small, positive changes in our daily interactions with others to truly make a lasting impact on society. It is our vision to bring people together and use the Lotus currency to account for the value we see in each other.

--- a/app/content/2.tools.yml
+++ b/app/content/2.tools.yml
@@ -1,17 +1,17 @@
-title: Tools for Prosperity
-description: Explore the tools that are available to the Lotusia ecosystem
-ogTitle: Tools for Prosperity - Lotusia
+title: Public Goods
+description: Open-source software and infrastructure produced by the Lotusia Stewardship
+ogTitle: Public Goods - Lotusia
 ogDescription: Access the Lotusia Ecosystem
 ogImage: /img/tools_0.jpg
 to: /tools
 navigation.icon: i-mdi-fountain
 hero:
-  title: Tools for Prosperity
-  description: Explore the tools that are available to the Lotusia ecosystem
+  title: Public Goods
+  description: Open-source software and infrastructure produced by the Lotusia Stewardship for the benefit of the ecosystem
   image: /img/tools_0.jpg
 sections:
-  - title: Blockchain software - lotusd / Lotus QT
-    description: The core Lotus blockchain software—your gateway to the network. Runs a full, secure copy of the Treasury ledger, enabling you to participate in mining, validate transactions, and help secure the entire ecosystem. (Required for all miners.)
+  - title: Core Blockchain Software
+    description: The Stewardship maintains lotusd and Lotus-QT, the reference implementation of the Lotus blockchain protocol. This software validates transactions, maintains the distributed ledger, and enables anyone to participate in network consensus through mining.
     headline: 'Winter Solstice 2025 - 10th Epoch of the Lotus Network'
     version: '10.4.9'
     align: right
@@ -48,8 +48,8 @@ sections:
         to: github/lotusd
         icon: i-mdi-github
         target: _blank
-  - title: Lotus Developer SDK
-    description: A comprehensive TypeScript library for building applications and integrating with the Lotus blockchain ecosystem.
+  - title: Developer SDK
+    description: A TypeScript library developed by the Stewardship for building applications that integrate with the Lotus blockchain. Includes support for transactions, wallets, MuSig2 multi-signatures, Taproot addresses, and other cryptographic primitives.
     version: '0.1.0'
     align: left
     images:
@@ -75,8 +75,8 @@ sections:
         target: _blank
         icon: i-heroicons-book-open
         type: README & Docs
-  - title: Lotusia Chrome Extension
-    description: A decentralized, community-moderated reputation system for social media, powered by Lotus.
+  - title: Browser Extension
+    description: A reference implementation of the RANK protocol, developed by the Stewardship as a Chrome extension. Demonstrates how decentralized reputation systems can be built on top of the Lotus blockchain.
     align: right
     images:
       - src: /img/extension_1.jpeg
@@ -100,8 +100,8 @@ sections:
         target: _blank
         icon: i-mdi-google-chrome
         type: Chrome Extension
-  - title: BigVase Mobile Wallet
-    description: Your personal Lotus wallet for iPhone and Android. Give, receive, and manage your Lotus on the go with a wallet you control—no middleman required.
+  - title: Mobile Wallet Reference Implementation
+    description: BigVase is a reference implementation of a non-custodial Lotus wallet, developed by the Stewardship to demonstrate best practices for mobile wallet development on the Lotus blockchain.
     align: left
     images:
       - src: /img/bigvase_1.jpeg


### PR DESCRIPTION
…itioning

Restore original homepage content from pre-265c151 state and reframe messaging to position lotusia.org as the Stewardship development team website rather than a promotional tool.

Changes:
- Restore "Restoring Humanity to Society" hero and original sections
- Replace "Technology for Prosperity" with "Public Goods for the Ecosystem"
- Reframe /tools page from "Tools for Prosperity" to "Public Goods"
- Emphasize Stewardship as producer of open-source public goods
- Remove promotional language for specific products
- Add descriptive language about reference implementations

The website now reads as the Stewardship's communication hub, describing the public goods produced for the ecosystem without promoting specific tools.