### PR TITLE
feat(server): add Nitro server plugins for Chronik, RANK, and RPC cli…

### DIFF
--- a/app/server/api/explorer/address/[address]/balance.ts
+++ b/app/server/api/explorer/address/[address]/balance.ts
@@ -1,15 +1,12 @@
-import { Bitcore } from 'lotus-sdk'
-import { useChronikApi } from '@/composables/useChronikApi'
+import { Bitcore } from 'xpi-ts'
 
-const { getUtxos } = useChronikApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const address = getRouterParam(event, 'address')
 
   if (!address) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing address'
+      statusMessage: 'Missing address',
     })
   }
 
@@ -19,12 +16,13 @@ export default defineEventHandler(async (event) => {
   if (!scriptType || !scriptPayload) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid address'
+      statusMessage: 'Invalid address',
     })
   }
 
+  const { $chronik } = useNitroApp()
   // fetch utxos and calculate balance
-  const utxos = await getUtxos(scriptType, scriptPayload)
+  const utxos = await $chronik.getUtxos(scriptType, scriptPayload)
   const balance = utxos
     .reduce((acc, utxo) => acc + Number(utxo.value), 0)
     .toString()

--- a/app/server/api/explorer/address/[address]/index.ts
+++ b/app/server/api/explorer/address/[address]/index.ts
@@ -1,22 +1,19 @@
-import { Bitcore } from 'lotus-sdk'
-import { useChronikApi } from '@/composables/useChronikApi'
+import { Script } from 'xpi-ts/lib/bitcore'
 import { getSumBurnedSats } from '~/utils/transaction'
 import {
   EXPLORER_TABLE_MAX_ROWS,
   NetworkCharacter,
-  Network
+  Network,
 } from '~/utils/constants'
 
-const { getTxHistoryPage } = useChronikApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const address = getRouterParam(event, 'address')
   const { page, pageSize } = getQuery(event)
 
   if (!address) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing address'
+      statusMessage: 'Missing address',
     })
   }
 
@@ -25,31 +22,32 @@ export default defineEventHandler(async (event) => {
   if (networkChar !== NetworkCharacter) {
     throw createError({
       statusCode: 400,
-      statusMessage: `Address is not a ${Network} address`
+      statusMessage: `Address is not a ${Network} address`,
     })
   }
 
-  const script = Bitcore.Script.fromAddress(address)
+  const script = Script.fromAddress(address)
   const scriptType = script.getType()
   const scriptPayload = script.getData().toString('hex')
   if (!scriptType || !scriptPayload) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid address'
+      statusMessage: 'Invalid address',
     })
   }
 
   const pageNum = Number(page) || 1
   const pageSizeNum = Number(pageSize) || 10
 
-  const history = await getTxHistoryPage(
+  const { $chronik } = useNitroApp()
+  const history = await $chronik.getTxHistoryPage(
     scriptType,
     scriptPayload,
     // Chronik tx history page is 0-indexed, but we want to show the user a 1-indexed page
     pageNum > 0 ? pageNum - 1 : 0,
     pageSizeNum > EXPLORER_TABLE_MAX_ROWS
       ? EXPLORER_TABLE_MAX_ROWS
-      : pageSizeNum
+      : pageSizeNum,
   )
 
   // find the address last seen time
@@ -61,13 +59,13 @@ export default defineEventHandler(async (event) => {
   }
   const txs = history.txs.map(tx => ({
     ...tx,
-    sumBurnedSats: getSumBurnedSats(tx).toString()
+    sumBurnedSats: getSumBurnedSats(tx).toString(),
   }))
 
   return {
     lastSeen,
     // TODO: Add this back when we have a way to calculate the total burned sats for an address
     // numBurnedSats: txs.reduce((acc, tx) => acc + BigInt(tx.sumBurnedSats), BigInt(0)).toString(),
-    history: { txs, numPages: history.numPages }
+    history: { txs, numPages: history.numPages },
   }
 })

--- a/app/server/api/explorer/block/[hashOrHeight].ts
+++ b/app/server/api/explorer/block/[hashOrHeight].ts
@@ -1,4 +1,3 @@
-import { useChronikApi } from '@/composables/useChronikApi'
 import { toAsyncIterable } from '~/utils/functions'
 import { getAddressFromScript } from '~/utils/address'
 import { getSumBurnedSats } from '~/utils/transaction'
@@ -8,23 +7,22 @@ type ExplorerBlock = Block & {
   minedBy: string
 }
 
-const { getBlock } = useChronikApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   // const t0 = performance.now()
   const hashOrHeight = getRouterParam(event, 'hashOrHeight')
   if (!hashOrHeight) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing hashOrHeight'
+      statusMessage: 'Missing hashOrHeight',
     })
   }
   try {
-    const block = await getBlock(hashOrHeight)
+    const { $chronik } = useNitroApp()
+    const block = await $chronik.getBlock(hashOrHeight)
     if (!block) {
       throw createError({
         statusCode: 404,
-        statusMessage: 'Block not found'
+        statusMessage: 'Block not found',
       })
     }
     /** height 0 is genesis block */
@@ -38,7 +36,7 @@ export default defineEventHandler(async (event) => {
     for await (const tx of toAsyncIterable(block.txs)) {
       txs.push({
         ...tx,
-        sumBurnedSats: getSumBurnedSats(tx).toString()
+        sumBurnedSats: getSumBurnedSats(tx).toString(),
       })
     }
     block.txs = txs
@@ -48,13 +46,13 @@ export default defineEventHandler(async (event) => {
 
     return {
       ...block,
-      minedBy: minedByAddress.toXAddress()
+      minedBy: minedByAddress.toXAddress(),
     } as ExplorerBlock
   } catch (error) {
     console.error(error)
     throw createError({
       statusCode: 404,
-      statusMessage: 'Block not found'
+      statusMessage: 'Block not found',
     })
   }
 })

--- a/app/server/api/explorer/blocks.ts
+++ b/app/server/api/explorer/blocks.ts
@@ -1,27 +1,28 @@
-import { useChronikApi } from '~/composables/useChronikApi'
 import { EXPLORER_TABLE_MAX_ROWS } from '~/utils/constants'
 
-const { getBlockchainInfo, getBlockRange } = useChronikApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const { page, pageSize } = getQuery(event)
   const pageNum = Number(page) || 1
   const pageSizeNum = Number(pageSize) || 10
   // need to get the blockchain info to get the tip height
-  const blockchainInfo = await getBlockchainInfo()
+  const { $chronik } = useNitroApp()
+  const blockchainInfo = await $chronik.getBlockchainInfo()
   const startHeight = blockchainInfo.tipHeight - pageSizeNum * pageNum
-  const endHeight = startHeight
-    + (pageSizeNum > EXPLORER_TABLE_MAX_ROWS ? EXPLORER_TABLE_MAX_ROWS : pageSizeNum)
+  const endHeight =
+    startHeight +
+    (pageSizeNum > EXPLORER_TABLE_MAX_ROWS
+      ? EXPLORER_TABLE_MAX_ROWS
+      : pageSizeNum)
   // get the block range
   // startHeight must be lowest height, endHeight must be highest height
-  const blockRange = await getBlockRange(
+  const blockRange = await $chronik.getBlockRange(
     startHeight + 1 > 0 ? startHeight + 1 : 1,
-    endHeight
+    endHeight,
   )
 
   // Reverse the block range to show the latest blocks first
   return {
     blocks: blockRange.reverse(),
-    tipHeight: blockchainInfo.tipHeight
+    tipHeight: blockchainInfo.tipHeight,
   }
 })

--- a/app/server/api/explorer/chain-info.ts
+++ b/app/server/api/explorer/chain-info.ts
@@ -1,7 +1,4 @@
-import { useChronikApi } from '~/composables/useChronikApi'
-
-const { getBlockchainInfo } = useChronikApi()
-
 export default defineEventHandler(async () => {
-  return await getBlockchainInfo()
+  const { $chronik } = useNitroApp()
+  return await $chronik.getBlockchainInfo()
 })

--- a/app/server/api/explorer/mempool.ts
+++ b/app/server/api/explorer/mempool.ts
@@ -1,9 +1,6 @@
-import RPC from '~/utils/rpc'
-
-const { getRawMemPool, getRawTransaction } = RPC
-
 export default defineEventHandler(async () => {
-  const txids = await getRawMemPool()
-  const txs = await Promise.all(txids.map(txid => getRawTransaction(txid)))
+  const { $rpc } = useNitroApp()
+  const txids = await $rpc.getRawMemPool()
+  const txs = await Promise.all(txids.map(txid => $rpc.getRawTransaction(txid)))
   return txs
 })

--- a/app/server/api/explorer/overview.ts
+++ b/app/server/api/explorer/overview.ts
@@ -1,13 +1,12 @@
 import { NODE_GEOIP_URL } from '~/utils/constants'
-import { useNodeRpc } from '~/composables/useNodeRpc'
 import type { GeoIPResponse } from '~/utils/types'
 import type * as RPC from '~/utils/rpc'
 
-const { getPeerInfo, getMiningInfo } = useNodeRpc()
 const runtimeCache = new Map<string, GeoIPResponse>()
 
 export default defineEventHandler(async () => {
-  const peerInfo = await getPeerInfo()
+  const { $rpc } = useNitroApp()
+  const peerInfo = await $rpc.getPeerInfo()
   const peers: RPC.PeerInfo[] = []
   for (const peer of peerInfo) {
     // only match IPv4 addresses
@@ -15,7 +14,11 @@ export default defineEventHandler(async () => {
       continue
     }
     // skip private IP addresses
-    if (peer.addr.match(/^10\./) || peer.addr.match(/^172\.16\./) || peer.addr.match(/^192\.168\./)) {
+    if (
+      peer.addr.match(/^10\./) ||
+      peer.addr.match(/^172\.16\./) ||
+      peer.addr.match(/^192\.168\./)
+    ) {
       continue
     }
     const ip = peer.addr.split(':')[0]
@@ -23,25 +26,25 @@ export default defineEventHandler(async () => {
       peers.push({
         ...peer,
         addr: ip,
-        geoip: runtimeCache.get(ip)!.data
+        geoip: runtimeCache.get(ip)!.data,
       })
       continue
     }
     const response = await fetch(`${NODE_GEOIP_URL}/${ip}`)
-    const json = await response.json() as GeoIPResponse
+    const json = (await response.json()) as GeoIPResponse
     // console.log('GeoIP response for IP', ip, json)
     if (json.success) {
       runtimeCache.set(ip, json)
       peers.push({
         ...peer,
         addr: ip,
-        geoip: json.data
+        geoip: json.data,
       })
     }
   }
-  const miningInfo = await getMiningInfo()
+  const miningInfo = await $rpc.getMiningInfo()
   return {
     mininginfo: miningInfo,
-    peerinfo: peers
+    peerinfo: peers,
   }
 })

--- a/app/server/api/explorer/tx/[txid].ts
+++ b/app/server/api/explorer/tx/[txid].ts
@@ -1,10 +1,7 @@
-import { Bitcore } from 'lotus-sdk'
-import { ScriptProcessor, type TransactionOutputRANK } from 'lotus-sdk/lib/rank'
+import { BufferUtil, Script } from 'xpi-ts/lib/bitcore'
+import { ScriptProcessor, type TransactionOutputRANK } from 'xpi-ts/lib/rank'
 import type { Tx, TxInput, TxOutput } from 'chronik-client'
-import { useChronikApi } from '@/composables/useChronikApi'
 import { getAddressFromScript } from '@/utils/address'
-
-const { getBlockchainInfo, getTransaction } = useChronikApi()
 
 type ExplorerTxInput = TxInput & {
   address: string
@@ -22,23 +19,24 @@ type ExplorerTx = Tx & {
   sumBurnedSats: string
 }
 
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const txid = getRouterParam(event, 'txid')
   if (!txid) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing txid'
+      statusMessage: 'Missing txid',
     })
   }
-  const tx = await getTransaction(txid)
+  const { $chronik } = useNitroApp()
+  const tx = await $chronik.getTransaction(txid)
   if (!tx) {
     throw createError({
       statusCode: 404,
-      statusMessage: 'Transaction not found'
+      statusMessage: 'Transaction not found',
     })
   }
 
-  const blockchainInfo = await getBlockchainInfo()
+  const blockchainInfo = await $chronik.getBlockchainInfo()
   const confirmations = tx.block
     ? blockchainInfo.tipHeight - tx.block.height + 1
     : -1
@@ -47,17 +45,21 @@ export default defineEventHandler(async (event) => {
     if (!input.outputScript) {
       return input
     }
-    const script = Bitcore.Script.fromHex(input.outputScript)
+    const script = Script.fromHex(input.outputScript)
 
     // P2PKH/P2TR/P2SH outputs
-    if (script.isPayToPublicKeyHash() || script.isPayToScriptHash() || script.isPayToTaproot()) {
+    if (
+      script.isPublicKeyHashOut() ||
+      script.isScriptHashOut() ||
+      script.isTaprootOut()
+    ) {
       const address = getAddressFromScript(script).toXAddress()
       if (!address) {
         return input
       }
       return {
         ...input,
-        address
+        address,
       } as ExplorerTxInput
     }
     // return the input as is
@@ -66,8 +68,8 @@ export default defineEventHandler(async (event) => {
 
   let sumBurnedSats = 0
   const txOutputs = tx.outputs.map((output: TxOutput) => {
-    const scriptBuf = Buffer.from(output.outputScript, 'hex')
-    const script = Bitcore.Script.fromBuffer(scriptBuf)
+    const scriptBuf = BufferUtil.from(output.outputScript, 'hex')
+    const script = Script.fromBuffer(scriptBuf)
     // OP_RETURN outputs
     if (script.isDataOut()) {
       // TODO: we can add more LOKAD checks here
@@ -78,19 +80,23 @@ export default defineEventHandler(async (event) => {
       if (rankOutput) {
         return {
           ...output,
-          rankOutput
+          rankOutput,
         } as ExplorerTxOutput
       }
     }
     // P2PKH/P2TR/P2SH outputs
-    if (script.isPayToPublicKeyHash() || script.isPayToScriptHash() || script.isPayToTaproot()) {
+    if (
+      script.isPublicKeyHashOut() ||
+      script.isScriptHashOut() ||
+      script.isTaprootOut()
+    ) {
       const address = getAddressFromScript(script).toXAddress()
       if (!address) {
         return output
       }
       return {
         ...output,
-        address
+        address,
       } as ExplorerTxOutput
     }
     // if we get here, the output is not a rank output or an address output
@@ -103,6 +109,6 @@ export default defineEventHandler(async (event) => {
     confirmations,
     inputs: txInputs,
     outputs: txOutputs,
-    sumBurnedSats: sumBurnedSats.toString()
+    sumBurnedSats: sumBurnedSats.toString(),
   } as ExplorerTx
 })

--- a/app/server/api/social/[platform]/[profileId]/index.ts
+++ b/app/server/api/social/[platform]/[profileId]/index.ts
@@ -1,25 +1,26 @@
-import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk/lib/rank'
-import { useRankApi } from '~/composables/useRankApi'
+import {
+  PlatformConfiguration,
+  type ScriptChunkPlatformUTF8,
+} from 'lotus-sdk/lib/rank'
 
-const { getProfileRanking } = useRankApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const { platform: platformParam, profileId } = getRouterParams(event)
   const platform = platformParam as ScriptChunkPlatformUTF8
 
   if (!platform || !profileId) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform or profileId'
+      statusMessage: 'Invalid platform or profileId',
     })
   }
 
   if (PlatformConfiguration.get(platform) === undefined) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform'
+      statusMessage: 'Invalid platform',
     })
   }
 
-  return await getProfileRanking(platform, profileId)
+  const { $rankApi } = useNitroApp()
+  return await $rankApi.getProfileRanking(platform, profileId)
 })

--- a/app/server/api/social/[platform]/[profileId]/posts.ts
+++ b/app/server/api/social/[platform]/[profileId]/posts.ts
@@ -1,23 +1,23 @@
-import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk/lib/rank'
-import { useRankApi } from '~/composables/useRankApi'
+import {
+  PlatformConfiguration,
+  type ScriptChunkPlatformUTF8,
+} from 'lotus-sdk/lib/rank'
 
-const { getProfilePosts } = useRankApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const { platform: platformParam, profileId } = getRouterParams(event)
   const platform = platformParam as ScriptChunkPlatformUTF8
 
   if (!platform || !profileId) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform or profileId'
+      statusMessage: 'Invalid platform or profileId',
     })
   }
 
   if (PlatformConfiguration.get(platform) === undefined) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform'
+      statusMessage: 'Invalid platform',
     })
   }
 
@@ -25,10 +25,11 @@ export default defineEventHandler(async (event) => {
   const pageNumber = Number(page) || 1
   const pageSizeNumber = Number(pageSize) || 10
 
-  return await getProfilePosts(
+  const { $rankApi } = useNitroApp()
+  return await $rankApi.getProfilePosts(
     platform,
     profileId,
     pageNumber,
-    pageSizeNumber
+    pageSizeNumber,
   )
 })

--- a/app/server/api/social/[platform]/[profileId]/votes.ts
+++ b/app/server/api/social/[platform]/[profileId]/votes.ts
@@ -1,23 +1,23 @@
-import { PlatformConfiguration, type ScriptChunkPlatformUTF8 } from 'lotus-sdk/lib/rank'
-import { useRankApi } from '~/composables/useRankApi'
+import {
+  PlatformConfiguration,
+  type ScriptChunkPlatformUTF8,
+} from 'lotus-sdk/lib/rank'
 
-const { getProfileRankTransactions } = useRankApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const { platform: platformParam, profileId } = getRouterParams(event)
   const platform = platformParam as ScriptChunkPlatformUTF8
 
   if (!platform || !profileId) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform or profileId'
+      statusMessage: 'Invalid platform or profileId',
     })
   }
 
   if (PlatformConfiguration.get(platform) === undefined) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform'
+      statusMessage: 'Invalid platform',
     })
   }
 
@@ -25,10 +25,11 @@ export default defineEventHandler(async (event) => {
   const pageNumber = Number(page) || 1
   const pageSizeNumber = Number(pageSize) || 10
 
-  return await getProfileRankTransactions(
+  const { $rankApi } = useNitroApp()
+  return await $rankApi.getProfileRankTransactions(
     platform,
     profileId,
     pageNumber,
-    pageSizeNumber
+    pageSizeNumber,
   )
 })

--- a/app/server/api/social/activity.ts
+++ b/app/server/api/social/activity.ts
@@ -1,13 +1,10 @@
-import { useRankApi } from '~/composables/useRankApi'
-
-const { getVoteActivity } = useRankApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const { page, pageSize } = getQuery(event)
   const pageNum = Number(page) || 1
   const pageSizeNum = Number(pageSize) || 10
+  const { $rankApi } = useNitroApp()
   try {
-    return await getVoteActivity(pageNum, pageSizeNum)
+    return await $rankApi.getVoteActivity(pageNum, pageSizeNum)
   } catch (e) {
     return { votes: [], numPages: 0 }
   }

--- a/app/server/api/social/profiles.ts
+++ b/app/server/api/social/profiles.ts
@@ -1,10 +1,7 @@
-import { useRankApi } from '~/composables/useRankApi'
-
-const { getProfiles } = useRankApi()
-
-export default defineEventHandler(async (event) => {
+export default defineEventHandler(async event => {
   const { page, pageSize } = getQuery(event)
   const pageNum = Number(page) || 1
   const pageSizeNum = Number(pageSize) || 10
-  return await getProfiles(pageNum, pageSizeNum)
+  const { $rankApi } = useNitroApp()
+  return await $rankApi.getProfiles(pageNum, pageSizeNum)
 })

--- a/app/server/plugins/chronik-client.server.ts
+++ b/app/server/plugins/chronik-client.server.ts
@@ -1,0 +1,113 @@
+import { ChronikClient } from 'chronik-client'
+import type {
+  Block,
+  BlockInfo,
+  Tx,
+  BlockchainInfo,
+  ScriptType,
+  TxHistoryPage,
+  Utxo,
+} from 'chronik-client'
+import { CHRONIK_API_URL } from '~/utils/constants'
+
+export default defineNitroPlugin(nitroApp => {
+  const client = new ChronikClient(CHRONIK_API_URL as string)
+
+  const getBlockchainInfo = async (): Promise<BlockchainInfo> => {
+    try {
+      return await client.blockchainInfo()
+    } catch {
+      return {} as BlockchainInfo
+    }
+  }
+
+  const getBlock = async (hashOrHeight: string | number): Promise<Block> => {
+    try {
+      return await client.block(hashOrHeight)
+    } catch {
+      return {} as Block
+    }
+  }
+
+  const getBlockRange = async (
+    startHeight: number,
+    endHeight: number,
+  ): Promise<BlockInfo[]> => {
+    try {
+      return await client.blocks(startHeight, endHeight)
+    } catch {
+      return [] as BlockInfo[]
+    }
+  }
+
+  const getTransaction = async (hash: string): Promise<Tx> => {
+    try {
+      return await client.tx(hash)
+    } catch {
+      return {} as Tx
+    }
+  }
+
+  const getUtxos = async (
+    scriptType: ScriptType,
+    scriptPayload: string,
+  ): Promise<Utxo[]> => {
+    try {
+      const scriptEndpoint = client.script(scriptType, scriptPayload)
+      const [{ utxos }] = await scriptEndpoint.utxos()
+      return utxos
+    } catch {
+      return [] as Utxo[]
+    }
+  }
+
+  const getTxHistoryPage = async (
+    scriptType: ScriptType,
+    scriptPayload: string,
+    page: number,
+    pageSize: number,
+  ): Promise<TxHistoryPage> => {
+    try {
+      const scriptEndpoint = client.script(scriptType, scriptPayload)
+      const history = await scriptEndpoint.history(page, pageSize)
+      return history
+    } catch {
+      return {} as TxHistoryPage
+    }
+  }
+
+  nitroApp.$chronik = {
+    client,
+    getBlockchainInfo,
+    getBlock,
+    getBlockRange,
+    getTransaction,
+    getUtxos,
+    getTxHistoryPage,
+  }
+})
+
+declare module 'nitropack' {
+  interface NitroApp {
+    $chronik: {
+      client: ChronikClient
+      getBlockchainInfo: () => Promise<BlockchainInfo>
+      getBlock: (hashOrHeight: string | number) => Promise<Block>
+      getBlockRange: (
+        startHeight: number,
+        endHeight: number,
+      ) => Promise<BlockInfo[]>
+      getTransaction: (hash: string) => Promise<Tx>
+      getUtxos: (
+        scriptType: ScriptType,
+        scriptPayload: string,
+      ) => Promise<Utxo[]>
+      getTxHistoryPage: (
+        scriptType: ScriptType,
+        scriptPayload: string,
+        page: number,
+        pageSize: number,
+      ) => Promise<TxHistoryPage>
+    }
+  }
+}

--- a/app/server/plugins/rank-api.server.ts
+++ b/app/server/plugins/rank-api.server.ts
@@ -1,0 +1,510 @@
+import type { ProfileAPI, PostAPI } from 'xpi-ts/lib/rank/api'
+import type {
+  ScriptChunkPlatformUTF8,
+  ScriptChunkSentimentUTF8
+} from 'lotus-sdk/lib/rank'
+import type {
+  APIResponse,
+  WalletActivity,
+  WalletActivitySummary,
+  Timespan,
+  RankActivityResult,
+  WalletSummaryResult
+} from '~/types'
+import { RANK_API_URL } from '~/utils/constants'
+
+type VoterDetails = {
+  ranking: string
+  votesPositive: number
+  votesNegative: number
+  votesNeutral: number
+}
+
+type ProfileData = ProfileAPI & {
+  voters: VoterDetails[]
+}
+
+type VoteActivity = {
+  votes: RankTransactionAPI[]
+  numPages: number
+}
+
+type RankTransactionAPI = {
+  platform: ScriptChunkPlatformUTF8
+  profileId: string
+  postId: string
+  scriptPayload: string
+  txid: string
+  sentiment: ScriptChunkSentimentUTF8
+  firstSeen: string
+  timestamp: string
+  sats: string
+}
+
+type ProfileVoteActivity = {
+  votes: ProfileRankTransactionAPI[]
+  numPages: number
+}
+
+type ProfileRankTransactionAPI = {
+  txid: string
+  sentiment: ScriptChunkSentimentUTF8
+  timestamp: string
+  sats: string
+  post: {
+    id: string
+    ranking: string
+  }
+}
+
+type ProfilesAPI = {
+  profiles: Array<{
+    id: string
+    platform: ScriptChunkPlatformUTF8
+    ranking: string
+    satsPositive: string
+    satsNegative: string
+    votesPositive: number
+    votesNegative: number
+  }>
+  numPages: number
+}
+
+type ProfilePostsAPI = {
+  posts: Array<{
+    id: string
+    ranking: string
+    satsPositive: string
+    satsNegative: string
+    votesPositive: number
+    votesNegative: number
+  }>
+  numPages: number
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  const getProfiles = async (
+    page: number = 1,
+    pageSize: number = 10
+  ): Promise<ProfilesAPI> => {
+    const url = `${RANK_API_URL}/profiles/${page}/${pageSize}`
+    const response = await fetch(url)
+    return (await response.json()) as ProfilesAPI
+  }
+
+  const getProfilePosts = async (
+    platform: ScriptChunkPlatformUTF8,
+    profileId: string,
+    page: number = 1,
+    pageSize: number = 10
+  ): Promise<ProfilePostsAPI> => {
+    const url = `${RANK_API_URL}/${platform}/${profileId}/posts/${page}/${pageSize}`
+    const response = await fetch(url)
+    return (await response.json()) as ProfilePostsAPI
+  }
+
+  const getVoteActivity = async (
+    page: number = 1,
+    pageSize: number = 10
+  ): Promise<VoteActivity> => {
+    const url = `${RANK_API_URL}/votes/${page}/${pageSize}`
+    const response = await fetch(url)
+    return (await response.json()) as VoteActivity
+  }
+
+  const getTopRankedProfiles = async (
+    timespan: Timespan = 'today'
+  ): Promise<APIResponse[]> => {
+    const url = `${RANK_API_URL}/stats/profiles/top-ranked/${timespan}`
+    const response = await fetch(url)
+    return (await response.json()) as APIResponse[]
+  }
+
+  const getLowestRankedProfiles = async (
+    timespan: Timespan = 'today'
+  ): Promise<APIResponse[]> => {
+    const url = `${RANK_API_URL}/stats/profiles/lowest-ranked/${timespan}`
+    const response = await fetch(url)
+    return (await response.json()) as APIResponse[]
+  }
+
+  const getTopRankedPosts = async (
+    timespan: Timespan = 'today'
+  ): Promise<APIResponse[]> => {
+    const url = `${RANK_API_URL}/stats/posts/top-ranked/${timespan}`
+    const response = await fetch(url)
+    return (await response.json()) as APIResponse[]
+  }
+
+  const getLowestRankedPosts = async (
+    timespan: Timespan = 'today'
+  ): Promise<APIResponse[]> => {
+    const url = `${RANK_API_URL}/stats/posts/lowest-ranked/${timespan}`
+    const response = await fetch(url)
+    return (await response.json()) as APIResponse[]
+  }
+
+  const getProfileRanking = async (
+    platform: ScriptChunkPlatformUTF8,
+    profileId: string
+  ): Promise<ProfileData> => {
+    const url = `${RANK_API_URL}/${platform}/${profileId}`
+    const response = await fetch(url)
+    return (await response.json()) as ProfileData
+  }
+
+  const getProfileRankTransactions = async (
+    platform: ScriptChunkPlatformUTF8,
+    profileId: string,
+    page: number = 1,
+    pageSize: number = 10
+  ): Promise<ProfileVoteActivity> => {
+    const url = `${RANK_API_URL}/txs/${platform}/${profileId}/${page}/${pageSize}`
+    const response = await fetch(url)
+    return (await response.json()) as ProfileVoteActivity
+  }
+
+  const getPostRanking = async (
+    platform: ScriptChunkPlatformUTF8,
+    profileId: string,
+    postId: string
+  ): Promise<PostAPI> => {
+    const url = `${RANK_API_URL}/${platform}/${profileId}/${postId}`
+    const response = await fetch(url)
+    return (await response.json()) as PostAPI
+  }
+
+  const getWalletActivity = async (
+    scriptPayload: string,
+    startTime?: string,
+    endTime?: string
+  ): Promise<WalletActivity[]> => {
+    const url = `${RANK_API_URL}/wallet/${scriptPayload}${
+      startTime ? `/${startTime}` : ''
+    }${endTime ? `/${endTime}` : ''}`
+    const response = await fetch(url)
+    return await response.json()
+  }
+
+  const getWalletActivitySummary = async (
+    scriptPayload: string,
+    startTime?: Timespan,
+    endTime?: Timespan
+  ): Promise<WalletActivitySummary> => {
+    const url = `${RANK_API_URL}/wallet/summary/${scriptPayload}${
+      startTime ? `/${startTime}` : ''
+    }${endTime ? `/${endTime}` : ''}`
+    const response = await fetch(url)
+    return await response.json()
+  }
+
+  const getWeeklyWalletActivity = async (): Promise<RankActivityResult[]> => {
+    const url = `${RANK_API_URL}/charts/wallet/activity/week`
+    const response = await fetch(url)
+    return await response.json()
+  }
+
+  const getMonthlyWalletActivity = async (): Promise<RankActivityResult[]> => {
+    try {
+      const url = `${RANK_API_URL}/charts/wallet/activity/month`
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        console.warn(
+          'Monthly wallet activity endpoint returned error:',
+          response.status
+        )
+        return Array(30)
+          .fill(0)
+          .map(() => ({
+            totalVotes: 0,
+            totalPayoutsSent: 0,
+            totalPayoutAmount: 0,
+            broadcastWorkflowId: '',
+            broadcastRunId: ''
+          }))
+      }
+
+      const data = await response.json()
+      if (!Array.isArray(data) || data.length === 0) {
+        return Array(30)
+          .fill(0)
+          .map(() => ({
+            totalVotes: 0,
+            totalPayoutsSent: 0,
+            totalPayoutAmount: 0
+          }))
+      }
+      return data
+    } catch (error) {
+      console.error('Failed to fetch monthly wallet activity:', error)
+      return Array(30)
+        .fill(0)
+        .map(() => ({
+          totalVotes: 0,
+          totalPayoutsSent: 0,
+          totalPayoutAmount: 0
+        }))
+    }
+  }
+
+  const getQuarterlyWalletActivity = async (): Promise<
+    RankActivityResult[]
+  > => {
+    try {
+      const url = `${RANK_API_URL}/charts/wallet/activity/quarter`
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        console.warn(
+          'Quarterly wallet activity endpoint returned error:',
+          response.status
+        )
+        return Array(90)
+          .fill(0)
+          .map(() => ({
+            totalVotes: 0,
+            totalPayoutsSent: 0,
+            totalPayoutAmount: 0,
+            broadcastWorkflowId: '',
+            broadcastRunId: ''
+          }))
+      }
+
+      const data = await response.json()
+      if (!Array.isArray(data) || data.length === 0) {
+        return Array(90)
+          .fill(0)
+          .map(() => ({
+            totalVotes: 0,
+            totalPayoutsSent: 0,
+            totalPayoutAmount: 0
+          }))
+      }
+      return data
+    } catch (error) {
+      console.error('Failed to fetch quarterly wallet activity:', error)
+      return Array(90)
+        .fill(0)
+        .map(() => ({
+          totalVotes: 0,
+          totalPayoutsSent: 0,
+          totalPayoutAmount: 0
+        }))
+    }
+  }
+
+  const getWeeklyWalletSummary = async (): Promise<WalletSummaryResult> => {
+    try {
+      const url = `${RANK_API_URL}/charts/wallet/summary/week`
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        console.warn(
+          'Weekly wallet summary endpoint returned error:',
+          response.status
+        )
+        return {
+          totalVotes: 0,
+          totalUpvotes: 0,
+          totalDownvotes: 0,
+          totalUniqueWallets: 0,
+          totalSatsBurned: 0
+        }
+      }
+
+      const data = await response.json()
+      if (!data) {
+        return {
+          totalVotes: 0,
+          totalUpvotes: 0,
+          totalDownvotes: 0,
+          totalUniqueWallets: 0,
+          totalSatsBurned: 0
+        }
+      }
+      return data
+    } catch (error) {
+      console.error('Failed to fetch weekly wallet summary:', error)
+      return {
+        totalVotes: 0,
+        totalUpvotes: 0,
+        totalDownvotes: 0,
+        totalUniqueWallets: 0,
+        totalSatsBurned: 0
+      }
+    }
+  }
+
+  const getMonthlyWalletSummary = async (): Promise<WalletSummaryResult> => {
+    try {
+      const url = `${RANK_API_URL}/charts/wallet/summary/month`
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        console.warn(
+          'Monthly wallet summary endpoint returned error:',
+          response.status
+        )
+        return {
+          totalVotes: 0,
+          totalUpvotes: 0,
+          totalDownvotes: 0,
+          totalUniqueWallets: 0,
+          totalSatsBurned: 0
+        }
+      }
+
+      const data = await response.json()
+      if (!data) {
+        return {
+          totalVotes: 0,
+          totalUpvotes: 0,
+          totalDownvotes: 0,
+          totalUniqueWallets: 0,
+          totalSatsBurned: 0
+        }
+      }
+      return data
+    } catch (error) {
+      console.error('Failed to fetch monthly wallet summary:', error)
+      return {
+        totalVotes: 0,
+        totalUpvotes: 0,
+        totalDownvotes: 0,
+        totalUniqueWallets: 0,
+        totalSatsBurned: 0
+      }
+    }
+  }
+
+  const getQuarterlyWalletSummary = async (): Promise<WalletSummaryResult> => {
+    try {
+      const url = `${RANK_API_URL}/charts/wallet/summary/quarter`
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        console.warn(
+          'Quarterly wallet summary endpoint returned error:',
+          response.status
+        )
+        return {
+          totalVotes: 0,
+          totalUpvotes: 0,
+          totalDownvotes: 0,
+          totalUniqueWallets: 0,
+          totalSatsBurned: 0
+        }
+      }
+
+      const data = await response.json()
+      if (!data) {
+        return {
+          totalVotes: 0,
+          totalUpvotes: 0,
+          totalDownvotes: 0,
+          totalUniqueWallets: 0,
+          totalSatsBurned: 0
+        }
+      }
+      return data
+    } catch (error) {
+      console.error('Failed to fetch quarterly wallet summary:', error)
+      return {
+        totalVotes: 0,
+        totalUpvotes: 0,
+        totalDownvotes: 0,
+        totalUniqueWallets: 0,
+        totalSatsBurned: 0
+      }
+    }
+  }
+
+  const searchProfiles = async (query: string): Promise<ProfileAPI[]> => {
+    if (!query || query.trim().length < 2) return []
+    const url = `${RANK_API_URL}/search/profile/${query}`
+    try {
+      const response = await fetch(url)
+      return (await response.json()) as ProfileAPI[]
+    } catch (error) {
+      console.error('Error searching profiles:', error)
+      return []
+    }
+  }
+
+  nitroApp.$rankApi = {
+    getProfiles,
+    getProfilePosts,
+    getVoteActivity,
+    getTopRankedProfiles,
+    getLowestRankedProfiles,
+    getTopRankedPosts,
+    getLowestRankedPosts,
+    getProfileRanking,
+    getProfileRankTransactions,
+    getPostRanking,
+    getWalletActivity,
+    getWalletActivitySummary,
+    getWeeklyWalletActivity,
+    getMonthlyWalletActivity,
+    getQuarterlyWalletActivity,
+    getWeeklyWalletSummary,
+    getMonthlyWalletSummary,
+    getQuarterlyWalletSummary,
+    searchProfiles
+  }
+})
+
+declare module 'nitropack' {
+  interface NitroApp {
+    $rankApi: {
+      getProfiles: (page?: number, pageSize?: number) => Promise<ProfilesAPI>
+      getProfilePosts: (
+        platform: ScriptChunkPlatformUTF8,
+        profileId: string,
+        page?: number,
+        pageSize?: number
+      ) => Promise<ProfilePostsAPI>
+      getVoteActivity: (
+        page?: number,
+        pageSize?: number
+      ) => Promise<VoteActivity>
+      getTopRankedProfiles: (timespan?: Timespan) => Promise<APIResponse[]>
+      getLowestRankedProfiles: (timespan?: Timespan) => Promise<APIResponse[]>
+      getTopRankedPosts: (timespan?: Timespan) => Promise<APIResponse[]>
+      getLowestRankedPosts: (timespan?: Timespan) => Promise<APIResponse[]>
+      getProfileRanking: (
+        platform: ScriptChunkPlatformUTF8,
+        profileId: string
+      ) => Promise<ProfileData>
+      getProfileRankTransactions: (
+        platform: ScriptChunkPlatformUTF8,
+        profileId: string,
+        page?: number,
+        pageSize?: number
+      ) => Promise<ProfileVoteActivity>
+      getPostRanking: (
+        platform: ScriptChunkPlatformUTF8,
+        profileId: string,
+        postId: string
+      ) => Promise<PostAPI>
+      getWalletActivity: (
+        scriptPayload: string,
+        startTime?: string,
+        endTime?: string
+      ) => Promise<WalletActivity[]>
+      getWalletActivitySummary: (
+        scriptPayload: string,
+        startTime?: Timespan,
+        endTime?: Timespan
+      ) => Promise<WalletActivitySummary>
+      getWeeklyWalletActivity: () => Promise<RankActivityResult[]>
+      getMonthlyWalletActivity: () => Promise<RankActivityResult[]>
+      getQuarterlyWalletActivity: () => Promise<RankActivityResult[]>
+      getWeeklyWalletSummary: () => Promise<WalletSummaryResult>
+      getMonthlyWalletSummary: () => Promise<WalletSummaryResult>
+      getQuarterlyWalletSummary: () => Promise<WalletSummaryResult>
+      searchProfiles: (query: string) => Promise<ProfileAPI[]>
+    }
+  }
+}

--- a/app/server/plugins/rpc.server.ts
+++ b/app/server/plugins/rpc.server.ts
@@ -1,0 +1,212 @@
+import { LotusRPC } from '~/utils/constants'
+
+type NetworkInfo = {
+  subversion: string
+  localrelay: boolean
+  connections: number
+  connections_in: number
+  warnings: string
+}
+
+type MiningInfo = {
+  blocks: number
+  difficulty: number
+  networkhashps: number
+  pooledtx: number
+  chain: string
+  warnings: string
+}
+
+type MempoolInfo = {
+  loaded: boolean
+  size: number
+  bytes: number
+  usage: number
+  maxmempool: number
+  mempoolminfee: number
+  minrelaytxfee: number
+  unbroadcastcount: number
+}
+
+type PeerInfo = {
+  addr: string
+  services: string
+  servicesnames: Array<string>
+  relaytxes: boolean
+  lastsend: number
+  lastrecv: number
+  last_transaction: number
+  last_proof: number
+  last_block: number
+  bytessent: number
+  bytesrecv: number
+  conntime: number
+  timeoffset: number
+  pingtime: number
+  minping: number
+  version: number
+  subver: string
+  inbound: boolean
+  startingheight: number
+  synced_headers: number
+  synced_blocks: number
+  geoip?: {
+    country: string
+    city: string
+  }
+}
+
+type BlockStats = {
+  avgfee: number
+  avgfeerate: number
+  avgtxsize: number
+  blockhash: string
+  feerate_percentiles: Array<number>
+  height: number
+  ins: number
+  maxfee: number
+  maxfeerate: number
+  maxtxsize: number
+  medianfee: number
+  medianfeerate: number
+  mediantxsize: number
+  minfeerate: number
+  mintxsize: number
+  notx: number
+  outs: number
+  subsidy: number
+  time: number
+  total_out: number
+  total_size: number
+  totalfee: number
+  txs: number
+  utxo_increase: number
+  utxo_size_inc: number
+}
+
+type BlockInfo = {
+  hash: string
+  confirmations: number
+  size: number
+  height: number
+  tx: Array<string>
+  time: number
+  difficulty: number
+  nTx: number
+  previousblockhash: string
+  nextblockhash: string
+}
+
+type TransactionInput = {
+  txid: string
+  vout: number
+  coinbase?: string
+}
+
+type TransactionOutput = {
+  value: number
+  scriptPubKey: {
+    addresses: Array<string>
+    type: string
+    asm: string
+  }
+}
+
+type RawTransaction = {
+  txid: string
+  size: number
+  vin: TransactionInput[]
+  vout: TransactionOutput[]
+  time?: number
+  blocktime?: number
+  blockhash?: string
+  confirmations?: number
+}
+
+const { user, password, address, port } = LotusRPC
+const rpcUrl = `http://${address}:${port}`
+
+const sendRPCRequest = async (method: string, params: unknown[]) => {
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    body: JSON.stringify({ method, params }),
+    credentials: 'include',
+    headers: new Headers({
+      Authorization: `Basic ${Buffer.from(`${user}:${password}`).toString('base64')}`
+    })
+  })
+  const json = await response.json()
+  if (json.error) {
+    throw new Error(json.error)
+  }
+  return json.result
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  const getMiningInfo = async (): Promise<MiningInfo> =>
+    sendRPCRequest('getmininginfo', [])
+
+  const getPeerInfo = async (): Promise<PeerInfo[]> =>
+    sendRPCRequest('getpeerinfo', [])
+
+  const getBlockCount = async (): Promise<number> =>
+    sendRPCRequest('getblockcount', [])
+
+  const getBlockHash = async (height: number): Promise<string> =>
+    sendRPCRequest('getblockhash', [height])
+
+  const getBlockStats = async (hash: string): Promise<BlockStats> =>
+    sendRPCRequest('getblockstats', [hash])
+
+  const getBlock = async (hash: string): Promise<BlockInfo> =>
+    sendRPCRequest('getblock', [hash])
+
+  const getRawTransaction = async (txid: string): Promise<RawTransaction> =>
+    sendRPCRequest('getrawtransaction', [txid, true])
+
+  const getRawMemPool = async (): Promise<string[]> =>
+    sendRPCRequest('getrawmempool', [])
+
+  const getMempoolInfo = async (): Promise<MempoolInfo> =>
+    sendRPCRequest('getmempoolinfo', [])
+
+  nitroApp.$rpc = {
+    getMiningInfo,
+    getPeerInfo,
+    getBlockCount,
+    getBlockHash,
+    getBlockStats,
+    getBlock,
+    getRawTransaction,
+    getRawMemPool,
+    getMempoolInfo
+  }
+})
+
+declare module 'nitropack' {
+  interface NitroApp {
+    $rpc: {
+      getMiningInfo: () => Promise<MiningInfo>
+      getPeerInfo: () => Promise<PeerInfo[]>
+      getBlockCount: () => Promise<number>
+      getBlockHash: (height: number) => Promise<string>
+      getBlockStats: (hash: string) => Promise<BlockStats>
+      getBlock: (hash: string) => Promise<BlockInfo>
+      getRawTransaction: (txid: string) => Promise<RawTransaction>
+      getRawMemPool: () => Promise<string[]>
+      getMempoolInfo: () => Promise<MempoolInfo>
+    }
+  }
+}
+
+export type {
+  NetworkInfo,
+  MiningInfo,
+  MempoolInfo,
+  PeerInfo,
+  BlockStats,
+  BlockInfo,
+  TransactionInput,
+  TransactionOutput,
+  RawTransaction
+}


### PR DESCRIPTION
…ents

Add three Nitro server plugins to provide centralized client management via Nitro's dependency injection pattern:

- chronik-client.server.ts: Chronik blockchain indexer client
- rank-api.server.ts: RANK protocol REST API client
- rpc.server.ts: lotusd JSON-RPC client

All plugins attach to nitroApp.$namespace for consistent access patterns across server API routes. Includes TypeScript module declarations for type safety.

Refactors 13 API routes to use the new plugin-based clients:
- explorer/*: block, tx, address, mempool, chain-info
- social/*: profiles, posts, votes, activity