### PR TITLE
chore(deps): migrate from to xpi-ts npm package

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,1 @@
-install-links=true
+install-links=false

--- a/app/composables/useAvatars.ts
+++ b/app/composables/useAvatars.ts
@@ -1,19 +1,21 @@
-import type { ScriptChunkPlatformUTF8 } from 'lotus-sdk/lib/rank'
+import type { ScriptChunkPlatformUTF8 } from 'xpi-ts/lib/rank'
 import {
   getProfileAvatar,
   getProfileInitials,
-  getProfileColor
+  getProfileColor,
 } from '~/utils/avatar'
 
 /**
- * Composable for handling profile avatars with caching
+ * Composable for managing profile avatars with caching and loading states.
+ *
+ * Provides methods to fetch avatar URLs, track loading status, and preload avatars.
+ * Uses local caching to avoid repeated API requests for the same profile.
  */
 export function useAvatars() {
   // Cache for avatar URLs to avoid repeated requests
   const avatarCache = ref<Record<string, string>>({})
   // Cache for loading states
   const loadingAvatars = ref<Record<string, boolean>>({})
-
   /**
    * Get an avatar URL for a profile, with caching
    *
@@ -30,7 +32,7 @@ export function useAvatars() {
         src: avatarCache.value[cacheKey],
         loading: false,
         initials: getProfileInitials(profileId),
-        color: getProfileColor(profileId)
+        color: getProfileColor(profileId),
       }
     }
 
@@ -50,7 +52,7 @@ export function useAvatars() {
         src: avatarUrl,
         loading: false,
         initials: getProfileInitials(profileId),
-        color: getProfileColor(profileId)
+        color: getProfileColor(profileId),
       }
     } catch (error) {
       console.error('Error fetching avatar:', error)
@@ -61,7 +63,7 @@ export function useAvatars() {
         src: null,
         loading: false,
         initials: getProfileInitials(profileId),
-        color: getProfileColor(profileId)
+        color: getProfileColor(profileId),
       }
     }
   }
@@ -75,7 +77,7 @@ export function useAvatars() {
    */
   function isAvatarLoading(
     platform: ScriptChunkPlatformUTF8,
-    profileId: string
+    profileId: string,
   ) {
     const cacheKey = `${platform}:${profileId}`
     return loadingAvatars.value[cacheKey] || false
@@ -87,9 +89,9 @@ export function useAvatars() {
    * @param profiles Array of profile objects with platform and profileId
    */
   async function preloadAvatars(
-    profiles: Array<{ platform: string, profileId: string }>
+    profiles: Array<{ platform: string; profileId: string }>,
   ) {
-    profiles.forEach((profile) => {
+    profiles.forEach(profile => {
       getAvatar(profile.platform, profile.profileId)
     })
   }
@@ -101,6 +103,6 @@ export function useAvatars() {
     // functions
     getAvatar,
     isAvatarLoading,
-    preloadAvatars
+    preloadAvatars,
   }
 }

--- a/app/composables/useLokadParser.ts
+++ b/app/composables/useLokadParser.ts
@@ -1,4 +1,4 @@
-import { Bitcore } from 'lotus-sdk'
+import { Script } from 'xpi-ts/lib/bitcore'
 
 type ParsedScript = {
   type: 'rank'
@@ -9,7 +9,7 @@ export const useLokadParser = () => {
   const scripts: Map<string, ParsedScript> = new Map()
 
   const getLokadPrefix = (outputScript: string) => {
-    const script = Bitcore.Script.fromHex(outputScript)
+    const script = Script.fromHex(outputScript)
     if (!script.isDataOut()) {
       return null
     }

--- a/app/composables/useRankApi.ts
+++ b/app/composables/useRankApi.ts
@@ -1,4 +1,4 @@
-import type { ProfileAPI, PostAPI } from 'lotus-sdk'
+import type { ProfileAPI, PostAPI } from 'xpi-ts/lib/rank/api'
 import type {
   ScriptChunkPlatformUTF8,
   ScriptChunkSentimentUTF8

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,7 +21,8 @@
         "date-fns": "4.1.0",
         "lotus-sdk": "0.1.17",
         "nuxt": "^3.17.5",
-        "nuxt-site-config": "3.2.11"
+        "nuxt-site-config": "3.2.11",
+        "xpi-ts": "0.2.22"
       },
       "devDependencies": {
         "@iconify-json/mdi": "^1.2.3",
@@ -27866,6 +27867,34 @@
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xpi-ts": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/xpi-ts/-/xpi-ts-0.2.22.tgz",
+      "integrity": "sha512-4iB65VtOjhZWBFqEKSe7xuHA9Ves3yN5AXnlcYmadO6HURq2IgUP5mUEVCu0xxRtO/nh+bQh+V1KFAxzdCSVnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.7.2",
+        "bn.js": "5.2.2",
+        "bs58": "6.0.0",
+        "buffer": "6.0.3",
+        "elliptic": "6.6.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/xpi-ts/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/xss": {

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,8 @@
     "date-fns": "4.1.0",
     "lotus-sdk": "0.1.17",
     "nuxt": "^3.17.5",
-    "nuxt-site-config": "3.2.11"
+    "nuxt-site-config": "3.2.11",
+    "xpi-ts": "0.2.22"
   },
   "devDependencies": {
     "@iconify-json/mdi": "^1.2.3",

--- a/app/utils/address.ts
+++ b/app/utils/address.ts
@@ -1,4 +1,5 @@
-import { Bitcore } from 'lotus-sdk'
+import type { Address, NetworkName } from 'xpi-ts/lib/bitcore'
+import { Script } from 'xpi-ts/lib/bitcore'
 import { Network } from './constants'
 
 /**
@@ -6,19 +7,17 @@ import { Network } from './constants'
  * @param script - The script to get the address from
  * @returns The address
  */
-const getAddressFromScript = (
-  script: Bitcore.Script | string
-): Bitcore.Address => {
+const getAddressFromScript = (script: Script | string): Address => {
   // get Bitcore script
   if (typeof script === 'string') {
-    script = Bitcore.Script.fromHex(script)
+    script = Script.fromHex(script)
   }
   // OP_RETURN outputs are not addresses
   if (script.isDataOut()) {
     return null
   }
   // P2PKH, P2TR, and P2SH outputs are addresses
-  return script.toAddress(Network)
+  return script.toAddress(Network as NetworkName)
 }
 
 export { getAddressFromScript }

--- a/app/utils/chronik.ts
+++ b/app/utils/chronik.ts
@@ -1,16 +1,33 @@
 import { Bitcore } from 'lotus-sdk'
+import type { Tx } from 'chronik-client'
+
+/**
+ * Calculate the sum of the burned sats in a transaction
+ * @param tx - The transaction to calculate the sum of burned sats for
+ * @returns The sum of the burned sats, in bigint format
+ */
+export function calcSumBurnedSats(tx: Tx): bigint {
+  return tx.outputs.reduce((acc, output) => {
+    const value = BigInt(output.value)
+    // 0x6a = OP_RETURN
+    if (output.outputScript.startsWith('6a') && value > BigInt(0)) {
+      return acc + value
+    }
+    return acc
+  }, BigInt(0))
+}
 
 /**
  * Get the Bitcore `Script` for the provided `Address`
  * @param address - The `Address` to get the script for, in string or `Address` format
  * @returns The Bitcore `Script`
  */
-const getScriptFromAddress = (
+export function getScriptFromAddress(
   address: string | Bitcore.Address
-): Bitcore.Script => {
+): Bitcore.Script {
   try {
     return Bitcore.Script.fromAddress(address)
-  } catch (e: any) {
+  } catch (e) {
     throw new Error(`getScriptFromAddress: ${e.message}`)
   }
 }
@@ -20,9 +37,7 @@ const getScriptFromAddress = (
  * @param data - The `Script` or `Address` to get the script payload for
  * @returns The script payload
  */
-const getScriptPayload = (address: Bitcore.Address | string): string => {
+export function getScriptPayload(address: Bitcore.Address | string): string {
   const script = getScriptFromAddress(address)
   return script.getData().toString('hex')
 }
-
-export { getScriptFromAddress, getChronikScriptType, getScriptPayload }

--- a/app/utils/transaction.ts
+++ b/app/utils/transaction.ts
@@ -1,6 +1,6 @@
 import type { Tx } from 'chronik-client'
 
-function getSumBurnedSats(tx: Tx): bigint {
+export function getSumBurnedSats(tx: Tx): bigint {
   return tx.outputs.reduce((acc, output) => {
     const value = BigInt(output.value)
     // 0x6a = OP_RETURN
@@ -9,8 +9,4 @@ function getSumBurnedSats(tx: Tx): bigint {
     }
     return acc
   }, BigInt(0))
-}
-
-export {
-  getSumBurnedSats
 }

--- a/app/utils/wallet.ts
+++ b/app/utils/wallet.ts
@@ -1,4 +1,4 @@
-import type { Bitcore } from 'lotus-sdk'
+import type { Bitcore } from 'xpi-ts'
 
 enum BIP44CoinType {
   default = 10605,


### PR DESCRIPTION
- Add xpi-ts as an npm dependency replacing the local xpi-ts link
- Remove link installation from .npmrc (no longer needed)
- Update composables and utilities to import from xpi-ts package