### PR TITLE
fix(deps): update xpi-ts to v0.2.24 and apply server lint fixes

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,7 +21,7 @@
         "date-fns": "4.1.0",
         "nuxt": "^3.17.5",
         "nuxt-site-config": "3.2.11",
-        "xpi-ts": "0.2.22"
+        "xpi-ts": "^0.2.24"
       },
       "devDependencies": {
         "@iconify-json/mdi": "^1.2.3",
@@ -2685,6 +2685,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11765,9 +11777,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -26055,9 +26067,9 @@
       }
     },
     "node_modules/xpi-ts": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/xpi-ts/-/xpi-ts-0.2.22.tgz",
-      "integrity": "sha512-4iB65VtOjhZWBFqEKSe7xuHA9Ves3yN5AXnlcYmadO6HURq2IgUP5mUEVCu0xxRtO/nh+bQh+V1KFAxzdCSVnA==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/xpi-ts/-/xpi-ts-0.2.24.tgz",
+      "integrity": "sha512-RX8jVeC70guWD/vk1KrQT017WVuVQV+VpjXc1r7Lxg4GW/jJ+p+M4oBExVzb2B6BrRfzH8e8X8FAx/XclPW2dw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.7.2",
@@ -26068,18 +26080,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/xpi-ts/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/xss": {

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "date-fns": "4.1.0",
     "nuxt": "^3.17.5",
     "nuxt-site-config": "3.2.11",
-    "xpi-ts": "0.2.22"
+    "xpi-ts": "^0.2.24"
   },
   "devDependencies": {
     "@iconify-json/mdi": "^1.2.3",

--- a/app/server/api/explorer/address/[address]/balance.ts
+++ b/app/server/api/explorer/address/[address]/balance.ts
@@ -1,12 +1,12 @@
 import { Bitcore } from 'xpi-ts'
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const address = getRouterParam(event, 'address')
 
   if (!address) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing address',
+      statusMessage: 'Missing address'
     })
   }
 
@@ -16,7 +16,7 @@ export default defineEventHandler(async event => {
   if (!scriptType || !scriptPayload) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid address',
+      statusMessage: 'Invalid address'
     })
   }
 

--- a/app/server/api/explorer/address/[address]/index.ts
+++ b/app/server/api/explorer/address/[address]/index.ts
@@ -3,17 +3,17 @@ import { getSumBurnedSats } from '~/utils/transaction'
 import {
   EXPLORER_TABLE_MAX_ROWS,
   NetworkCharacter,
-  Network,
+  Network
 } from '~/utils/constants'
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const address = getRouterParam(event, 'address')
   const { page, pageSize } = getQuery(event)
 
   if (!address) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing address',
+      statusMessage: 'Missing address'
     })
   }
 
@@ -22,7 +22,7 @@ export default defineEventHandler(async event => {
   if (networkChar !== NetworkCharacter) {
     throw createError({
       statusCode: 400,
-      statusMessage: `Address is not a ${Network} address`,
+      statusMessage: `Address is not a ${Network} address`
     })
   }
 
@@ -32,7 +32,7 @@ export default defineEventHandler(async event => {
   if (!scriptType || !scriptPayload) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid address',
+      statusMessage: 'Invalid address'
     })
   }
 
@@ -47,7 +47,7 @@ export default defineEventHandler(async event => {
     pageNum > 0 ? pageNum - 1 : 0,
     pageSizeNum > EXPLORER_TABLE_MAX_ROWS
       ? EXPLORER_TABLE_MAX_ROWS
-      : pageSizeNum,
+      : pageSizeNum
   )
 
   // find the address last seen time
@@ -59,13 +59,13 @@ export default defineEventHandler(async event => {
   }
   const txs = history.txs.map(tx => ({
     ...tx,
-    sumBurnedSats: getSumBurnedSats(tx).toString(),
+    sumBurnedSats: getSumBurnedSats(tx).toString()
   }))
 
   return {
     lastSeen,
     // TODO: Add this back when we have a way to calculate the total burned sats for an address
     // numBurnedSats: txs.reduce((acc, tx) => acc + BigInt(tx.sumBurnedSats), BigInt(0)).toString(),
-    history: { txs, numPages: history.numPages },
+    history: { txs, numPages: history.numPages }
   }
 })

--- a/app/server/api/explorer/block/[hashOrHeight].ts
+++ b/app/server/api/explorer/block/[hashOrHeight].ts
@@ -7,13 +7,13 @@ type ExplorerBlock = Block & {
   minedBy: string
 }
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   // const t0 = performance.now()
   const hashOrHeight = getRouterParam(event, 'hashOrHeight')
   if (!hashOrHeight) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing hashOrHeight',
+      statusMessage: 'Missing hashOrHeight'
     })
   }
   try {
@@ -22,7 +22,7 @@ export default defineEventHandler(async event => {
     if (!block) {
       throw createError({
         statusCode: 404,
-        statusMessage: 'Block not found',
+        statusMessage: 'Block not found'
       })
     }
     /** height 0 is genesis block */
@@ -36,7 +36,7 @@ export default defineEventHandler(async event => {
     for await (const tx of toAsyncIterable(block.txs)) {
       txs.push({
         ...tx,
-        sumBurnedSats: getSumBurnedSats(tx).toString(),
+        sumBurnedSats: getSumBurnedSats(tx).toString()
       })
     }
     block.txs = txs
@@ -46,13 +46,13 @@ export default defineEventHandler(async event => {
 
     return {
       ...block,
-      minedBy: minedByAddress.toXAddress(),
+      minedBy: minedByAddress.toXAddress()
     } as ExplorerBlock
   } catch (error) {
     console.error(error)
     throw createError({
       statusCode: 404,
-      statusMessage: 'Block not found',
+      statusMessage: 'Block not found'
     })
   }
 })

--- a/app/server/api/explorer/blocks.ts
+++ b/app/server/api/explorer/blocks.ts
@@ -1,6 +1,6 @@
 import { EXPLORER_TABLE_MAX_ROWS } from '~/utils/constants'
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const { page, pageSize } = getQuery(event)
   const pageNum = Number(page) || 1
   const pageSizeNum = Number(pageSize) || 10
@@ -8,21 +8,21 @@ export default defineEventHandler(async event => {
   const { $chronik } = useNitroApp()
   const blockchainInfo = await $chronik.getBlockchainInfo()
   const startHeight = blockchainInfo.tipHeight - pageSizeNum * pageNum
-  const endHeight =
-    startHeight +
-    (pageSizeNum > EXPLORER_TABLE_MAX_ROWS
+  const endHeight
+    = startHeight
+    + (pageSizeNum > EXPLORER_TABLE_MAX_ROWS
       ? EXPLORER_TABLE_MAX_ROWS
       : pageSizeNum)
   // get the block range
   // startHeight must be lowest height, endHeight must be highest height
   const blockRange = await $chronik.getBlockRange(
     startHeight + 1 > 0 ? startHeight + 1 : 1,
-    endHeight,
+    endHeight
   )
 
   // Reverse the block range to show the latest blocks first
   return {
     blocks: blockRange.reverse(),
-    tipHeight: blockchainInfo.tipHeight,
+    tipHeight: blockchainInfo.tipHeight
   }
 })

--- a/app/server/api/explorer/overview.ts
+++ b/app/server/api/explorer/overview.ts
@@ -15,9 +15,9 @@ export default defineEventHandler(async () => {
     }
     // skip private IP addresses
     if (
-      peer.addr.match(/^10\./) ||
-      peer.addr.match(/^172\.16\./) ||
-      peer.addr.match(/^192\.168\./)
+      peer.addr.match(/^10\./)
+      || peer.addr.match(/^172\.16\./)
+      || peer.addr.match(/^192\.168\./)
     ) {
       continue
     }
@@ -26,7 +26,7 @@ export default defineEventHandler(async () => {
       peers.push({
         ...peer,
         addr: ip,
-        geoip: runtimeCache.get(ip)!.data,
+        geoip: runtimeCache.get(ip)!.data
       })
       continue
     }
@@ -38,13 +38,13 @@ export default defineEventHandler(async () => {
       peers.push({
         ...peer,
         addr: ip,
-        geoip: json.data,
+        geoip: json.data
       })
     }
   }
   const miningInfo = await $rpc.getMiningInfo()
   return {
     mininginfo: miningInfo,
-    peerinfo: peers,
+    peerinfo: peers
   }
 })

--- a/app/server/api/explorer/tx/[txid].ts
+++ b/app/server/api/explorer/tx/[txid].ts
@@ -19,12 +19,12 @@ type ExplorerTx = Tx & {
   sumBurnedSats: string
 }
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const txid = getRouterParam(event, 'txid')
   if (!txid) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Missing txid',
+      statusMessage: 'Missing txid'
     })
   }
   const { $chronik } = useNitroApp()
@@ -32,7 +32,7 @@ export default defineEventHandler(async event => {
   if (!tx) {
     throw createError({
       statusCode: 404,
-      statusMessage: 'Transaction not found',
+      statusMessage: 'Transaction not found'
     })
   }
 
@@ -49,9 +49,9 @@ export default defineEventHandler(async event => {
 
     // P2PKH/P2TR/P2SH outputs
     if (
-      script.isPublicKeyHashOut() ||
-      script.isScriptHashOut() ||
-      script.isTaprootOut()
+      script.isPublicKeyHashOut()
+      || script.isScriptHashOut()
+      || script.isTaprootOut()
     ) {
       const address = getAddressFromScript(script).toXAddress()
       if (!address) {
@@ -59,7 +59,7 @@ export default defineEventHandler(async event => {
       }
       return {
         ...input,
-        address,
+        address
       } as ExplorerTxInput
     }
     // return the input as is
@@ -80,15 +80,15 @@ export default defineEventHandler(async event => {
       if (rankOutput) {
         return {
           ...output,
-          rankOutput,
+          rankOutput
         } as ExplorerTxOutput
       }
     }
     // P2PKH/P2TR/P2SH outputs
     if (
-      script.isPublicKeyHashOut() ||
-      script.isScriptHashOut() ||
-      script.isTaprootOut()
+      script.isPublicKeyHashOut()
+      || script.isScriptHashOut()
+      || script.isTaprootOut()
     ) {
       const address = getAddressFromScript(script).toXAddress()
       if (!address) {
@@ -96,7 +96,7 @@ export default defineEventHandler(async event => {
       }
       return {
         ...output,
-        address,
+        address
       } as ExplorerTxOutput
     }
     // if we get here, the output is not a rank output or an address output
@@ -109,6 +109,6 @@ export default defineEventHandler(async event => {
     confirmations,
     inputs: txInputs,
     outputs: txOutputs,
-    sumBurnedSats: sumBurnedSats.toString(),
+    sumBurnedSats: sumBurnedSats.toString()
   } as ExplorerTx
 })

--- a/app/server/api/social/[platform]/[profileId]/index.ts
+++ b/app/server/api/social/[platform]/[profileId]/index.ts
@@ -1,23 +1,23 @@
 import {
   PlatformConfiguration,
-  type ScriptChunkPlatformUTF8,
+  type ScriptChunkPlatformUTF8
 } from 'xpi-ts/lib/lokad'
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const { platform: platformParam, profileId } = getRouterParams(event)
   const platform = platformParam as ScriptChunkPlatformUTF8
 
   if (!platform || !profileId) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform or profileId',
+      statusMessage: 'Invalid platform or profileId'
     })
   }
 
   if (PlatformConfiguration.get(platform) === undefined) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform',
+      statusMessage: 'Invalid platform'
     })
   }
 

--- a/app/server/api/social/[platform]/[profileId]/posts.ts
+++ b/app/server/api/social/[platform]/[profileId]/posts.ts
@@ -1,23 +1,23 @@
 import {
   PlatformConfiguration,
-  type ScriptChunkPlatformUTF8,
+  type ScriptChunkPlatformUTF8
 } from 'xpi-ts/lib/lokad'
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const { platform: platformParam, profileId } = getRouterParams(event)
   const platform = platformParam as ScriptChunkPlatformUTF8
 
   if (!platform || !profileId) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform or profileId',
+      statusMessage: 'Invalid platform or profileId'
     })
   }
 
   if (PlatformConfiguration.get(platform) === undefined) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform',
+      statusMessage: 'Invalid platform'
     })
   }
 
@@ -30,6 +30,6 @@ export default defineEventHandler(async event => {
     platform,
     profileId,
     pageNumber,
-    pageSizeNumber,
+    pageSizeNumber
   )
 })

--- a/app/server/api/social/[platform]/[profileId]/votes.ts
+++ b/app/server/api/social/[platform]/[profileId]/votes.ts
@@ -1,23 +1,23 @@
 import {
   PlatformConfiguration,
-  type ScriptChunkPlatformUTF8,
+  type ScriptChunkPlatformUTF8
 } from 'xpi-ts/lib/lokad'
 
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const { platform: platformParam, profileId } = getRouterParams(event)
   const platform = platformParam as ScriptChunkPlatformUTF8
 
   if (!platform || !profileId) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform or profileId',
+      statusMessage: 'Invalid platform or profileId'
     })
   }
 
   if (PlatformConfiguration.get(platform) === undefined) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Invalid platform',
+      statusMessage: 'Invalid platform'
     })
   }
 
@@ -30,6 +30,6 @@ export default defineEventHandler(async event => {
     platform,
     profileId,
     pageNumber,
-    pageSizeNumber,
+    pageSizeNumber
   )
 })

--- a/app/server/api/social/activity.ts
+++ b/app/server/api/social/activity.ts
@@ -1,4 +1,4 @@
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const { page, pageSize } = getQuery(event)
   const pageNum = Number(page) || 1
   const pageSizeNum = Number(pageSize) || 10

--- a/app/server/api/social/profiles.ts
+++ b/app/server/api/social/profiles.ts
@@ -1,4 +1,4 @@
-export default defineEventHandler(async event => {
+export default defineEventHandler(async (event) => {
   const { page, pageSize } = getQuery(event)
   const pageNum = Number(page) || 1
   const pageSizeNum = Number(pageSize) || 10

--- a/app/server/plugins/chronik-client.server.ts
+++ b/app/server/plugins/chronik-client.server.ts
@@ -6,12 +6,12 @@ import type {
   BlockchainInfo,
   ScriptType,
   TxHistoryPage,
-  Utxo,
+  Utxo
 } from 'chronik-client'
 import { CHRONIK_API_URL } from '~/utils/constants'
 
-export default defineNitroPlugin(nitroApp => {
-  const client = new ChronikClient(CHRONIK_API_URL as string)
+export default defineNitroPlugin((nitroApp) => {
+  const client = new ChronikClient(CHRONIK_API_URL)
 
   const getBlockchainInfo = async (): Promise<BlockchainInfo> => {
     try {
@@ -31,7 +31,7 @@ export default defineNitroPlugin(nitroApp => {
 
   const getBlockRange = async (
     startHeight: number,
-    endHeight: number,
+    endHeight: number
   ): Promise<BlockInfo[]> => {
     try {
       return await client.blocks(startHeight, endHeight)
@@ -50,7 +50,7 @@ export default defineNitroPlugin(nitroApp => {
 
   const getUtxos = async (
     scriptType: ScriptType,
-    scriptPayload: string,
+    scriptPayload: string
   ): Promise<Utxo[]> => {
     try {
       const scriptEndpoint = client.script(scriptType, scriptPayload)
@@ -65,7 +65,7 @@ export default defineNitroPlugin(nitroApp => {
     scriptType: ScriptType,
     scriptPayload: string,
     page: number,
-    pageSize: number,
+    pageSize: number
   ): Promise<TxHistoryPage> => {
     try {
       const scriptEndpoint = client.script(scriptType, scriptPayload)
@@ -83,7 +83,7 @@ export default defineNitroPlugin(nitroApp => {
     getBlockRange,
     getTransaction,
     getUtxos,
-    getTxHistoryPage,
+    getTxHistoryPage
   }
 })
 

--- a/app/server/plugins/rank-api.server.ts
+++ b/app/server/plugins/rank-api.server.ts
@@ -2,7 +2,7 @@ import type { ProfileAPI, PostAPI } from 'xpi-ts/lib/rank/api'
 import type {
   ScriptChunkPlatformUTF8,
   ScriptChunkSentimentUTF8
-} from 'lotus-sdk/lib/rank'
+} from 'xpi-ts/lib/lokad'
 import type {
   APIResponse,
   WalletActivity,
@@ -463,11 +463,11 @@ declare module 'nitropack' {
         platform: ScriptChunkPlatformUTF8,
         profileId: string,
         page?: number,
-        pageSize?: number
+        pageSize?: number,
       ) => Promise<ProfilePostsAPI>
       getVoteActivity: (
         page?: number,
-        pageSize?: number
+        pageSize?: number,
       ) => Promise<VoteActivity>
       getTopRankedProfiles: (timespan?: Timespan) => Promise<APIResponse[]>
       getLowestRankedProfiles: (timespan?: Timespan) => Promise<APIResponse[]>
@@ -475,28 +475,28 @@ declare module 'nitropack' {
       getLowestRankedPosts: (timespan?: Timespan) => Promise<APIResponse[]>
       getProfileRanking: (
         platform: ScriptChunkPlatformUTF8,
-        profileId: string
+        profileId: string,
       ) => Promise<ProfileData>
       getProfileRankTransactions: (
         platform: ScriptChunkPlatformUTF8,
         profileId: string,
         page?: number,
-        pageSize?: number
+        pageSize?: number,
       ) => Promise<ProfileVoteActivity>
       getPostRanking: (
         platform: ScriptChunkPlatformUTF8,
         profileId: string,
-        postId: string
+        postId: string,
       ) => Promise<PostAPI>
       getWalletActivity: (
         scriptPayload: string,
         startTime?: string,
-        endTime?: string
+        endTime?: string,
       ) => Promise<WalletActivity[]>
       getWalletActivitySummary: (
         scriptPayload: string,
         startTime?: Timespan,
-        endTime?: Timespan
+        endTime?: Timespan,
       ) => Promise<WalletActivitySummary>
       getWeeklyWalletActivity: () => Promise<RankActivityResult[]>
       getMonthlyWalletActivity: () => Promise<RankActivityResult[]>

--- a/app/server/plugins/rpc.server.ts
+++ b/app/server/plugins/rpc.server.ts
@@ -1,6 +1,6 @@
 import { LotusRPC } from '~/utils/constants'
 
-type NetworkInfo = {
+interface NetworkInfo {
   subversion: string
   localrelay: boolean
   connections: number
@@ -8,7 +8,7 @@ type NetworkInfo = {
   warnings: string
 }
 
-type MiningInfo = {
+interface MiningInfo {
   blocks: number
   difficulty: number
   networkhashps: number
@@ -17,7 +17,7 @@ type MiningInfo = {
   warnings: string
 }
 
-type MempoolInfo = {
+interface MempoolInfo {
   loaded: boolean
   size: number
   bytes: number
@@ -28,7 +28,7 @@ type MempoolInfo = {
   unbroadcastcount: number
 }
 
-type PeerInfo = {
+interface PeerInfo {
   addr: string
   services: string
   servicesnames: Array<string>
@@ -56,7 +56,7 @@ type PeerInfo = {
   }
 }
 
-type BlockStats = {
+interface BlockStats {
   avgfee: number
   avgfeerate: number
   avgtxsize: number
@@ -84,7 +84,7 @@ type BlockStats = {
   utxo_size_inc: number
 }
 
-type BlockInfo = {
+interface BlockInfo {
   hash: string
   confirmations: number
   size: number
@@ -97,13 +97,13 @@ type BlockInfo = {
   nextblockhash: string
 }
 
-type TransactionInput = {
+interface TransactionInput {
   txid: string
   vout: number
   coinbase?: string
 }
 
-type TransactionOutput = {
+interface TransactionOutput {
   value: number
   scriptPubKey: {
     addresses: Array<string>
@@ -112,7 +112,7 @@ type TransactionOutput = {
   }
 }
 
-type RawTransaction = {
+interface RawTransaction {
   txid: string
   size: number
   vin: TransactionInput[]


### PR DESCRIPTION
Update xpi-ts dependency to v0.2.24. Run ESLint --fix on server directory
to ensure consistent code formatting across 14 API and plugin files.

Updating to xpi-ts@0.2.24 is necessary to fix the broken `elliptic` import
during Nitro runtime.

Changes:
- package.json: bump xpi-ts to v0.2.24
- server/api/explorer/*: formatting fixes
- server/api/social/*: formatting fixes  
- server/plugins/*: formatting fixes